### PR TITLE
Wl pprint annotated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ tags
 /_site/
 /.dir-locals.el
 /src/Language/Parser/Lexer.hs
+happyinfo.txt

--- a/language-rust.cabal
+++ b/language-rust.cabal
@@ -51,6 +51,8 @@ library
 test-suite tests
   hs-source-dirs:      tests
   main-is:             Main.hs
+  other-modules:       LexerTest
+                       ParserTest
   Type:                exitcode-stdio-1.0
   default-language:    Haskell2010
   build-depends:       base >=4.9 && <4.10

--- a/language-rust.cabal
+++ b/language-rust.cabal
@@ -53,12 +53,14 @@ test-suite tests
   main-is:             Main.hs
   other-modules:       LexerTest
                        ParserTest
+                       PrettyTest
   Type:                exitcode-stdio-1.0
   default-language:    Haskell2010
   build-depends:       base >=4.9 && <4.10
                      , Cabal >= 1.10.0
                      , transformers >=0.5 && <0.6
                      , HUnit
+                     , pretty >=1.1 && <1.2
                      , test-framework
                      , test-framework-hunit >= 0.3.0
                      , language-rust

--- a/language-rust.cabal
+++ b/language-rust.cabal
@@ -23,6 +23,7 @@ library
   exposed-modules:     Language.Rust.Pretty
                        Language.Rust.Syntax.Token
                        Language.Rust.Syntax.Ident
+                       Language.Rust.Syntax.Constants
                        Language.Rust.Syntax.AST
                        Language.Rust.Parser.ParseMonad
                        Language.Rust.Parser.Lexer

--- a/language-rust.cabal
+++ b/language-rust.cabal
@@ -41,7 +41,6 @@ library
                      , DeriveFunctor
 
   build-depends:       base >=4.9 && <4.10
-                     , pretty >=1.1 && <1.2
                      , wl-pprint-annotated >= 0.0.1 && < 0.0.2
                      , transformers >=0.5 && <0.6
                      , array >=0.5 && <0.6

--- a/language-rust.cabal
+++ b/language-rust.cabal
@@ -26,7 +26,7 @@ library
                        Language.Rust.Syntax.AST
                        Language.Rust.Parser.ParseMonad
                        Language.Rust.Parser.Lexer
- --                      Language.Rust.Parser.Parser2
+                       Language.Rust.Parser.Parser2
                        Language.Rust.Data.Position
                        Language.Rust.Data.InputStream
   -- other-modules:

--- a/language-rust.cabal
+++ b/language-rust.cabal
@@ -42,6 +42,7 @@ library
 
   build-depends:       base >=4.9 && <4.10
                      , pretty >=1.1 && <1.2
+                     , wl-pprint-annotated >= 0.0.1 && < 0.0.2
                      , transformers >=0.5 && <0.6
                      , array >=0.5 && <0.6
                      , bytestring >= 0.10
@@ -61,6 +62,7 @@ test-suite tests
                      , transformers >=0.5 && <0.6
                      , HUnit
                      , pretty >=1.1 && <1.2
+                     , wl-pprint-annotated >= 0.0.1 && < 0.0.2
                      , test-framework
                      , test-framework-hunit >= 0.3.0
                      , language-rust

--- a/src/Language/Rust/Data/Position.hs
+++ b/src/Language/Rust/Data/Position.hs
@@ -2,9 +2,13 @@
 
 module Language.Rust.Data.Position where
 
+import Data.Ord (comparing)
+import Data.List (maximumBy, minimumBy)
+import Data.Monoid (Monoid, mappend, mempty)
+
 -- Taken and abbreviated from
--- | A position in a source file. The row and column information is kept only for its convenience
--- and human-readability.
+-- | A position in a source file. The row and column information is kept only
+-- for its convenience and human-readability.
 -- https://hackage.haskell.org/package/language-c-0.5.0/docs/src/Language-C-Data-Position.html#Position
 data Position = Position {
     absoluteOffset :: {-# UNPACK #-} !Int, -- ^ absolute offset the source file.
@@ -13,6 +17,17 @@ data Position = Position {
   }
   | NoPosition
   deriving (Eq, Ord)
+
+-- | Maximum and minimum positions, bias for actual positions in either case
+maxPos, minPos :: Position -> Position -> Position
+
+maxPos NoPosition p2 = p2
+maxPos p1 NoPosition = p1
+maxPos p1 p2 = maximumBy (comparing absoluteOffset) [p1,p2]
+
+minPos NoPosition p2 = p2
+minPos p1 NoPosition = p1
+minPos p1 p2 = minimumBy (comparing absoluteOffset) [p1,p2]
 
 -- | starting position in a file
 initPos :: Position
@@ -42,11 +57,13 @@ instance Show Position where
 type ExpnId = Int -- https://docs.serde.rs/syntex_pos/struct.ExpnId.html
 
 
--- | Spans represent a region of code, used for error reporting. Positions in spans are absolute positions from the
--- beginning of the codemap, not positions relative to FileMaps. Methods on the CodeMap can be used to relate spans
--- back to the original source. You must be careful if the span crosses more than one file - you will not be able to
--- use many of the functions on spans in codemap and you cannot assume that the length of the span = hi - lo; there may
--- be space in the BytePos range between files.
+-- | Spans represent a region of code, used for error reporting. Positions in
+-- spans are absolute positions from the beginning of the codemap, not
+-- positions relative to FileMaps. Methods on the CodeMap can be used to relate
+-- spans back to the original source. You must be careful if the span crosses
+-- more than one file - you will not be able to use many of the functions on 
+-- spans in codemap and you cannot assume that the length of the span = hi - lo;
+-- there may be space in the BytePos range between files.
 -- https://docs.serde.rs/syntex_syntax/ext/quote/rt/struct.Span.html
 data Span
   = Span {
@@ -55,10 +72,25 @@ data Span
     -- expnId :: ExpnId
   }
 
+-- Spans are merged by taking the smallest span that covers both arguments
+instance Monoid Span where
+  mempty = Span NoPosition NoPosition
+  s1 `mappend` s2 = Span (lo s1 `minPos` lo s2) (hi s1 `maxPos` hi s2)
+
 instance Show Span where
   show (Span lo hi) = show lo ++ " - " ++ show hi
 
+-- | A "tagging" of something with a 'Span' that describes its extent
 data Spanned a = Spanned { unspan :: a, span :: Span } deriving (Functor)
 
+instance Applicative Spanned where
+  pure x = Spanned x mempty
+  Spanned f s1 <*> Spanned x s2 = Spanned (f x) (s1 `mappend` s2)
+
+instance Monad Spanned where
+  return = pure
+  Spanned x s1 >>= f = let Spanned y s2 = f x in Spanned y (s1 `mappend` s2) 
+
 instance Show a => Show (Spanned a) where
-  show (Spanned n p) = "at " ++ show p ++ ": " ++ show n
+  show (Spanned p s) = "at " ++ show p ++ ": " ++ show s
+

--- a/src/Language/Rust/Data/Position.hs
+++ b/src/Language/Rust/Data/Position.hs
@@ -70,7 +70,7 @@ data Span
     lo :: Position,
     hi :: Position --,
     -- expnId :: ExpnId
-  }
+  } deriving (Eq)
 
 -- Spans are merged by taking the smallest span that covers both arguments
 instance Monoid Span where

--- a/src/Language/Rust/Parser/Lexer.x
+++ b/src/Language/Rust/Parser/Lexer.x
@@ -1110,8 +1110,8 @@ lexicalError = do
   fail ("Lexical error: the character " ++ show c ++ " does not fit here")
 
 -- | Signal a syntax error.
-parseError :: Spanned Token -> P a
-parseError (Spanned tok _) = do
+parseError :: TokenSpace Spanned -> P a
+parseError (TokenSpace (Spanned tok _) _) = do
   fail ("Syntax error: the symbol `" ++ show tok ++ "' does not fit here")
 
 

--- a/src/Language/Rust/Parser/Lexer.x
+++ b/src/Language/Rust/Parser/Lexer.x
@@ -4,7 +4,7 @@ module Language.Rust.Parser.Lexer (lexToken, lexTokens, lexRust, lexicalError, p
 import Language.Rust.Data.InputStream
 import Language.Rust.Data.Position
 import Language.Rust.Parser.ParseMonad
-import Language.Rust.Syntax.Token (Token(..), TokenSpace(..), Space(..), LitTok(..), BinOpToken(..), DelimToken(..))
+import Language.Rust.Syntax.Token (Token(..), TokenSpace(..), Space(..), LitTok(..), DelimToken(..))
 import Language.Rust.Syntax.Ident (mkIdent, Ident(..), Name(..))
 
 import Data.Word (Word8)
@@ -935,36 +935,19 @@ tokens :-
 
 $white+         { \s -> pure (Space Whitespace (Name s))  }
 
-"="             { token Eq }
-"<"             { token Lt }
-"<="            { token Le }
-"=="            { token EqEq }
-">="            { token Ge }
-">"             { token Gt }
-"&&"            { token AndAnd }
-"||"            { token OrOr }
+"="             { token Equal }
+"<"             { token Less }
+">"             { token Greater }
+"&"             { token Ampersand }
+"|"             { token Pipe }
 "!"             { token Exclamation }
 "~"             { token Tilde }
-"+"             { token (BinOp Plus) }
-"-"             { token (BinOp Minus) }
-"*"             { token (BinOp Star) }
-"/"             { token (BinOp Slash) }
-"%"             { token (BinOp Percent) }
-"^"             { token (BinOp Caret) }
-"&"             { token (BinOp And) }
-"|"             { token (BinOp Or) }
-"<<"            { token (BinOp Shl) }
-">>"            { token (BinOp Shr) }
-"+="            { token (BinOpEq Plus) }
-"-="            { token (BinOpEq Minus) }
-"*="            { token (BinOpEq Star) }
-"/="            { token (BinOpEq Slash) }
-"%="            { token (BinOpEq Percent) }
-"^="            { token (BinOpEq Caret) }
-"&="            { token (BinOpEq And) }
-"|="            { token (BinOpEq Or) }
-"<<="           { token (BinOpEq Shl) }
-">>="           { token (BinOpEq Shr) }
+"+"             { token Plus }
+"-"             { token Minus }
+"*"             { token Star }
+"/"             { token Slash }
+"%"             { token Percent }
+"^"             { token Caret }
 "#!"            { token Shebang }
 
 "@"             { token At }          

--- a/src/Language/Rust/Parser/Lexer.x
+++ b/src/Language/Rust/Parser/Lexer.x
@@ -1076,7 +1076,7 @@ nestedComment = go 1 ""
           c' <- peekChar
           case c' of 
             Nothing -> fail "Unclosed comment"
-            Just '*' -> nextChar *> go (n+1) ('/':'*':s) 
+            Just '*' -> nextChar *> go (n+1) ('*':'/':s) 
             Just _ -> go n ('/':s)
         Just c' -> go n (c':s)
 

--- a/src/Language/Rust/Parser/ParseMonad.hs
+++ b/src/Language/Rust/Parser/ParseMonad.hs
@@ -10,8 +10,21 @@ import Language.Rust.Syntax.Ident
 import Control.Monad
 import Control.Monad.Trans.Except
 
+-- | Pattern for Identifiers
 pattern Identifier :: String -> Spanned Token
-pattern Identifier s <- (Spanned (IdentTok (Ident (Name s) _)) _) 
+pattern Identifier s <- (Spanned (IdentTok (Ident (Name s) _)) _)
+
+-- | Pattern for tokens preceded by space
+pattern SpTok :: Spanned Token -> TokenSpace Spanned
+pattern SpTok s <- (TokenSpace s (_:_))
+
+-- | Pattern for tokens not preceded by space
+pattern NoSpTok :: Spanned Token -> TokenSpace Spanned
+pattern NoSpTok s <- (TokenSpace s [])
+
+-- | Pattern for tokens (preceded or not by space)
+pattern Tok :: Spanned Token -> TokenSpace Spanned
+pattern Tok s <- (TokenSpace s _)
 
 -- | the result of running a parser
 data ParseResult a
@@ -58,12 +71,12 @@ execParser (P parser) input pos =
   case parser initialState of
     Failed message errpos -> throwE (errpos,message)
     Ok result _ -> return result
-  where initialState = PState {
-          curPos = pos,
-          curInput = input,
-          prevToken = error "CLexer.execParser: Touched undefined token!",
-          savedToken = error "CLexer.execParser: Touched undefined token (saved token)!"
-        }
+  where initialState = PState
+          { curPos = pos
+          , curInput = input
+          , prevToken = error "CLexer.execParser: Touched undefined token!"
+          , savedToken = error "CLexer.execParser: Touched undefined token (saved token)!"
+          }
 
 -- | update the position of the parser
 updatePosition :: (Position -> Position) -> P ()

--- a/src/Language/Rust/Parser/Parser2.y
+++ b/src/Language/Rust/Parser/Parser2.y
@@ -30,7 +30,7 @@ import Language.Rust.Syntax.AST
 %error { parseError }
 %lexer { lexRust } { Tok (Spanned Eof _) }
 
-%expect 0
+-- %expect 0
 
 %token
 
@@ -49,6 +49,21 @@ import Language.Rust.Syntax.AST
   '^'        { Tok $$@(Spanned Caret _) }
   '&'        { Tok $$@(Spanned Ampersand _) }
   '|'        { Tok $$@(Spanned Pipe _) }
+
+  EQ         { NoSpTok $$@(Spanned Equal _) }
+  LT         { Tok $$@(Spanned Less _) }
+  GT         { Tok $$@(Spanned Greater _) }
+  NOT        { Tok $$@(Spanned Exclamation _) }
+  
+  PLUS       { Tok $$@(Spanned Plus _) }
+  MINUS      { Tok $$@(Spanned Minus _) }
+  STAR       { Tok $$@(Spanned Star _) }
+  SLASH      { Tok $$@(Spanned Slash _) }
+  PERCENT    { Tok $$@(Spanned Percent _) }
+  CARET      { Tok $$@(Spanned Caret _) }
+  AMPERSAND  { Tok $$@(Spanned Ampersand _) }
+  PIPE       { Tok $$@(Spanned Pipe _) }
+
 
   -- Structural symbols.
   '@'        { Tok $$@(Spanned At _) }
@@ -108,8 +123,8 @@ import Language.Rust.Syntax.AST
   pub        { Tok $$@(Identifier "pub") } 
   ref        { Tok $$@(Identifier "ref") } 
   return     { Tok $$@(Identifier "return") }
-  selftype   { Tok $$@(Identifier "self") }
-  selfvalue  { Tok $$@(Identifier "Self") } 
+  Self       { Tok $$@(Identifier "self") }
+  self       { Tok $$@(Identifier "Self") } 
   static     { Tok $$@(Identifier "static") }
   struct     { Tok $$@(Identifier "struct") }
   super      { Tok $$@(Identifier "super") } 
@@ -141,7 +156,6 @@ import Language.Rust.Syntax.AST
 
   -- Weak keywords, have special meaning only in specific contexts.
   default    { Tok $$@(Identifier "default") } 
-  staticLife { Tok $$@(Identifier "'static") }
   union      { Tok $$@(Identifier "union") } 
 
   -- Comments
@@ -166,11 +180,11 @@ import Language.Rust.Syntax.AST
   strTyp     { Tok $$@(Identifier "str") }
 
   -- Identifiers.
-  ident      { Tok $$@(Identifier _) }
+  IDENT      { Tok $$@(Identifier _) }
   '_'        { Tok $$@(Spanned Underscore _) }
 
   -- Lifetimes.
-  lifetime   { Tok $$@(Spanned (LifetimeTok _) _) }
+  LIFETIME   { Tok $$@(Spanned (LifetimeTok _) _) }
 
 -- fake-precedence symbol to cause '|' bars in lambda context to parse
 -- at low precedence, permit things like |x| foo = bar, where '=' is
@@ -240,6 +254,30 @@ import Language.Rust.Syntax.AST
 %left RANGE              -- precedence
 
 %%
+---------------------
+-- Extended tokens --
+---------------------
+
+-- All of these have type 'Spanned ()'
+'<<=' : '<' LT EQ      { () <\$ $1 <* $2 <* $3 }
+'>>=' : '>' GT EQ      { () <\$ $1 <* $2 <* $3 }
+'-='  : '-' EQ         { () <\$ $1 <* $2 }
+'&='  : '&' EQ         { () <\$ $1 <* $2 }
+'|='  : '|' EQ         { () <\$ $1 <* $2 }
+'+='  : '+' EQ         { () <\$ $1 <* $2 }
+'*='  : '*' EQ         { () <\$ $1 <* $2 }
+'/='  : '/' EQ         { () <\$ $1 <* $2 }
+'^='  : '^' EQ         { () <\$ $1 <* $2 }
+'%='  : '%' EQ         { () <\$ $1 <* $2 }
+'||'  : '|' PIPE       { () <\$ $1 <* $2 }
+'&&'  : '&' AMPERSAND  { () <\$ $1 <* $2 }
+'=='  : '=' EQ         { () <\$ $1 <* $2 }
+'!='  : '!' EQ         { () <\$ $1 <* $2 }
+'<='  : '<' EQ         { () <\$ $1 <* $2 }
+'>='  : '>' EQ         { () <\$ $1 <* $2 }
+'<<'  : '<' LT         { () <\$ $1 <* $2 }
+'>>'  : '>' GT         { () <\$ $1 <* $2 }
+
 
 -------------
 -- Utility --
@@ -271,12 +309,371 @@ sep_by1(p,sep)  : p many(then(sep,p)) { $1 : $2 }
 -- | Sequence two parsers, return the result of the second (*>)
 then(a,b)       : a b                 { $2 }
 
+-- | Plus delimited, at least one
+plus(p)         : sep_by1(p,'+')      { $1 }
+
+-- | Comma delimited, at least one
+comma(p)        : sep_by1(p,',')      { $1 }
+
+-- | Comma delimited, allow trailing
+commaT(p)       : {- empty -}         { [] }
+                | comma(p) opt(',')   { $1 }
+
+-- | One or the other
+or(l,r)         : l                   { Left $1 }
+                | r                   { Right $1 }
+
+-- | One or the other, but of the same type
+alt(l,r)        : l                   { $1 }
+                | r                   { $1 }
+
+-- | Both
+and(l,r)        : l r                 { ($1, $2) }
+
+-------------
+-- General --
+-------------
+
+-- parse_qualified_path(PathStyle::Type)
+ty_qual_path :: { Spanned (QSelf Span, Path Span) }
+ty_qual_path : qual_path(path_segments_without_colons)   { $1 }
+
+-- parse_qualified_path(PathStyle::Expr)
+expr_qual_path :: { Spanned (QSelf Span, Path Span) }
+expr_qual_path : qual_path(path_segments_with_colons)    { $1 }
+
+qual_path(segs)
+      : '<' ty_sum opt(then(as, ty_path)) '>' '::' segs
+        { do
+            path1 <- maybe (pure (Path False [] mempty)) id $3
+            segs' <- (segments path1 ++) <\$> $6
+            qself <- QSelf <\$> $2 <*> pure (length (segments path1))
+            (qself, path1{ segments = segs' }) <\$ $1
+        }
+
+-- parse_path(PathStyle::Type)
+ty_path :: { Spanned (Path Span) }
+ty_path 
+      : path_segments_without_colons           %prec ident { withSpan (Path False <\$> $1) }
+      | '::' path_segments_without_colons      %prec ident { withSpan (Path True <\$> $2 <* $1) }
+
+-- parse_path(PathStyle::Expr)
+expr_path :: { Spanned (Path Span) }
+expr_path 
+      : path_segments_with_colons              %prec ident { withSpan (Path False <\$> $1) }
+      | '::' path_segments_with_colons         %prec ident { withSpan (Path True <\$> $2 <* $1) }
+
+-- parse_path_segments_without_colons()
+path_segments_without_colons :: { Spanned [(Ident, PathParameters Span)] }
+path_segments_without_colons : sep_by1(path_segment_without_colons, '::')  { sequence $1 } 
+
+-- No corresponding function - see parse_path_segments_without_colons
+path_segment_without_colons :: { Spanned (Ident, PathParameters Span) }
+path_segment_without_colons
+      : ident                                
+          {% if (not . isTypePathSegmentIdent . unspan \$ $1)
+               then fail "invalid path segment in type path"
+               else pure $ do
+                       i <- $1
+                       pure (i, AngleBracketed [] [] [] mempty)
+          }
+      | ident '<' generic_values_after_lt '>'
+          {% if (not . isTypePathSegmentIdent . unspan \$ $1)
+               then fail "invalid path segment in type path"
+               else pure $ do
+                       i <- $1
+                       let (lts, tys, bds) = $3
+                       ang <- withSpan (AngleBracketed <\$> lts <*> tys <*> bds <* $2 <* $4)
+                       pure (i, ang)
+          }
+      | ident '(' commaT(ty_sum) ')' opt(then('->', ty))
+          {% if (not . isTypePathSegmentIdent . unspan \$ $1)
+               then fail "invalid path segment in type path"
+               else pure $ do
+                      i <- $1
+                      args <- withSpan (Parenthesized <\$> sequence $3 <*> sequence $5 <* $2)
+                      pure (i, args)
+          }
+
+-- parse_path_segments_with_colons()
+path_segments_with_colons :: { Spanned [(Ident, PathParameters Span)] }
+path_segments_with_colons : sep_by1(path_segment_without_colons, '::')  { sequence $1 }
+
+-- No corresponding function - see parse_path_segments_with_colons
+path_segment_with_colons :: { Spanned (Ident, PathParameters Span) }
+path_segment_with_colons
+      : ident
+          {% if (not . isPathSegmentIdent . unspan \$ $1)
+               then fail "invalid path segment in expression path"
+               else pure ((,) <\$> $1 <*> pure (AngleBracketed [] [] [] mempty))
+          }
+      | ident '::' '<' generic_values_after_lt '>'
+          {% if (not . isPathSegmentIdent . unspan \$ $1)
+               then fail "invalid path segment in expression path"
+               else pure $ do
+                       i <- $1
+                       let (lts, tys, bds) = $4
+                       ang <- withSpan (AngleBracketed <\$> lts <*> tys <*> bds <* $5)
+                       pure (i, ang)
+          }
+
+-- parse_generic_values_after_lt()
+generic_values_after_lt :: { (Spanned [Lifetime Span], Spanned [Ty Span], Spanned [(Ident, Ty Span)]) }
+generic_values_after_lt
+      : comma(lifetime) ',' comma(ty_sum) ',' comma(binding) { (sequence $1, sequence $3, sequence $5) } 
+      |                     comma(ty_sum) ',' comma(binding) { (pure []    , sequence $1, sequence $3) }
+      | comma(lifetime) ','                   comma(binding) { (sequence $1, pure []    , sequence $3) }
+      | comma(lifetime) ',' comma(ty_sum)                    { (sequence $1, sequence $3, pure []    ) }
+      |                                       comma(binding) { (pure []    , pure []    , sequence $1) }
+      |                     comma(ty_sum)                    { (pure []    , sequence $1, pure []    ) } 
+      | comma(lifetime)                                      { (sequence $1, pure []    , pure []    )  }
+      |                                                      { (pure []    , pure []    , pure []    ) }
+
+-- parse_arg_general(false) -- does not require name
+arg_general :: { Spanned (Arg Span) } 
+arg_general
+      : arg             { $1 }
+      | ty_sum          { withSpan (Arg <\$> $1 <*> pure (IdentP (ByValue Immutable) invalidIdent Nothing mempty)) }
+
+-- parse_arg_general(true) -- requires name
+arg ::{ Spanned (Arg Span) }
+arg   : pat ':' ty_sum  { withSpan (Arg <\$> $3 <*> $1) }
 
 
-pat : {- Empty -}        { () }
+----------------
+-- Attributes --
+----------------
 
+-- parse_outer_attributes()
+outer_attributes :: { Spanned [Attribute Span] }
+outer_attribtues : {- Unimplemented -}                { error "Unimplemented" }
+
+--------------
+-- Patterns --
+--------------
+
+pat :: { Spanned (Pat Span) }
+pat   : '_'                                           { withSpan (WildP <\$ $1) }
+      | '&' pat                                       { withSpan (RefP <\$ $1 <*> $2 <*> pure Immutable) }
+      | '&' mut pat                                   { withSpan (RefP <\$ $1 <* $2 <*> $3 <*> pure Mutable) }
+      | '(' pats_list_context ')'                     { withSpan (TupleP <\$> snd $2 <*> pure (fst $2)) }
+      | '[' pats_list_binding ']'                     { $2 }
+      | lit                                           { withSpan (LitP <\$> $1) }
+      | '-' lit                                       { withSpan (LitP <\$> withSpan (Unary [] Neg <\$> $2)) }
+      | expr_path                                     { withSpan (PathP Nothing <\$> $1) }
+      | expr_qual_path                                { withSpan (PathP <\$> (Just . fst <\$> $1) <*> (snd <\$> $1)) }
+      | lit_or_path '...' lit_or_path                 { withSpan (RangeP <\$> $1 <*> $3) }
+      | expr_path '{' comma(pat_field) opt(',') '}'   { withSpan (StructP <\$> $1 <*> sequence $3 <*> pure False <* $5) }
+      | expr_path '{' comma(pat_field) ',' '..' '}'   { withSpan (StructP <\$> $1 <*> sequence $3 <*> pure True <* $6) }
+      | expr_path '{' '..' '}'                        { withSpan (StructP <\$> $1 <*> pure [] <*> pure True) }
+      | expr_path '(' pats_list_context ')'           { withSpan (TupleStructP <\$> $1 <*> snd $3 <*> pure (fst $3)) }
+  --  | expr_path '!' opt(ident) delimited_token_trees     { error "Unimplemented" } {- MacP (Mac a) a -}
+      | binding_mode ident '@' pat                    { withSpan (IdentP <\$> $1 <*> $2 <*> (Just <\$> $4)) }
+      | binding_mode ident                            { withSpan (IdentP <\$> $1 <*> $2 <*> pure Nothing) }
+      | box pat                                       { withSpan (BoxP <\$ $1 <*> $2) }
+
+pats_list_context :: { (Maybe Int, Spanned [Pat Span]) }
+pats_list_context
+      :                     '..'                                { (Nothing, [] <\$ $1) }
+      | comma(pat) opt(',')                                     { (Nothing, sequence $1) }
+      | comma(pat) opt(',') '..'                                { (Just (length $1), sequence $1 <* $3) }
+      |                     '..' opt(',') comma(pat) opt(',')   { (Just 0, sequence $3 <* $1) }
+      | comma(pat) opt(',') '..' opt(',') comma(pat) opt(',')   { (Just (length $1), (++) <\$> sequence $1 <*> sequence $5) }
+
+pats_list_binding :: { Spanned (Pat Span) }
+pats_list_binding
+      :                     opt(pat) '..'                                { withSpan (SliceP [] <\$> sequence $1 <*> pure [] <* $2) }
+      | comma(pat) opt(',')                                              { withSpan (SliceP <\$> sequence $1 <*> pure Nothing <*> pure []) }
+      | comma(pat) opt(',') opt(pat) '..'                                { withSpan (SliceP <\$> sequence $1 <*> sequence $3 <*> pure []) }
+      |                     opt(pat) '..' opt(',') comma(pat) opt(',')   { withSpan (SliceP [] <\$> sequence $1 <*> sequence $4) }
+      | comma(pat) opt(',') opt(pat) '..' opt(',') comma(pat) opt(',')   { withSpan (SliceP <\$> sequence $1 <*> sequence $3 <*> sequence $6) }
+
+pats_or :: { Spanned [Pat Span] }
+pats_or : sep_by1(pat,'|')                                               { sequence $1 }
+
+binding_mode :: { Spanned BindingMode }
+binding_mode
+      : ref mut     { ByRef Mutable <\$ $1 <* $2 }
+      | ref         { ByRef Immutable <\$ $1 }
+      | mut         { ByValue Mutable <\$ $1 }
+      | {- Empty -} { pure (ByValue Immutable) }
+
+lit_or_path :: { Spanned (Expr Span) }
+lit_or_path
+      : expr_path      { withSpan (PathExpr [] Nothing <\$> $1) } 
+      | expr_qual_path { withSpan (PathExpr [] <\$> (Just . fst <\$> $1) <*> (snd <\$> $1)) }
+      | lit            { $1 }
+      | '-' lit        { withSpan (Unary [] Neg <\$> $2 <* $1) }
+
+pat_field :: { Spanned (FieldPat Span) }
+pat_field
+      :     binding_mode ident     { withSpan (FieldPat <\$> $2 <*> withSpan (IdentP <\$> $1 <*> $2 <*> pure Nothing) <*> pure True) }
+      | box binding_mode ident     { withSpan (FieldPat <\$> $3 <*> withSpan (BoxP <\$> withSpan (IdentP <\$> $2 <*> $3 <*> pure  Nothing) <* $1) <*> pure True) }
+      | binding_mode ident ':' pat   { withSpan (FieldPat <\$> $2 <*> withSpan (IdentP <\$> $1 <*> $2 <*> (Just <\$> $4)) <*> pure True) }
+
+
+-----------
+-- Types --
+-----------
+
+-- parse_ty()
+ty :: { Spanned (Ty Span) }
+ty    : '(' ty_sum ',' comma(ty_sum) ')' { withSpan (TupTy <\$> ((:) <\$> $2 <*> sequence $4) <* $1 <* $5) }
+      | '(' ty_sum ',' ')'               { withSpan (TupTy <\$> (pure <\$> $2) <* $1 <* $4) }
+      | '(' ')'                          { withSpan (TupTy [] <\$ $1 <* $2) }
+      | '!'                              { withSpan (Never <\$ $1) }
+      | '*' maybe_mut_or_const ty        { withSpan (Ptr <\$> $2 <*> $3 <* $1) }
+      | '[' ty ']'                       { withSpan (Slice <\$> $2 <* $1 <* $3) }
+      | '[' ty ';' expr ']'              { withSpan (Array <\$> $2 <*> $4 <* $1 <* $5) }
+      | '&' opt(lifetime) maybe_mut ty   { withSpan (Rptr <\$> sequence $2 <*> $3 <*> $4 <* $1) }
+      | for_in_type                      { $1 }
+      | impl ty_param_bounds_mod         {% if (any isTraitTyParamBound (unspan $2))
+                                              then pure (withSpan (ImplTrait <\$> $2 <* $1))
+                                              else fail "at least one trait must be specified"
+                                         }
+      | ty_bare_fn                       { $1 (pure []) }
+      | typeof '(' expr ')'              { withSpan (Typeof <\$> $3 <* $1 <* $4) }
+      | ty_qual_path                     { withSpan (PathTy <\$> (Just . fst <\$> $1) <*> (snd <\$> $1)) }
+      | ty_path                          { withSpan (PathTy Nothing <\$> $1) }
+      | '_'                              { withSpan (Infer <\$ $1) }
+
+-- parse_ty_sum()
+ty_sum :: { Spanned (Ty Span) }
+ty_sum
+      : ty                             { $1 }
+      | ty '+' ty_param_bounds_bare    { withSpan (ObjectSum <\$> $1 <*> $3) }
+
+-- parse_ty_param_bounds(BoundParsingMode::Modified)
+ty_param_bounds_mod :: { Spanned [TyParamBound Span] }
+ty_param_bounds_mod : sep_by(or(lifetime, and(opt('?'),poly_trait_ref)),'+')
+        { sequence (map (\x -> case x of
+                                 Left l              -> RegionTyParamBound <\$> l
+                                 Right (Nothing,bnd) -> TraitTyParamBound <\$> bnd <*> pure None
+                                 Right (Just _,bnd)  -> TraitTyParamBound <\$> bnd <*> pure Maybe)
+                        $1)
+        }
+
+-- parse_ty_param_bounds(BoundParsingMode::Bare)
+ty_param_bounds_bare :: { Spanned [TyParamBound Span] }
+ty_param_bounds_bare : sep_by(or(lifetime, poly_trait_ref),'+')
+        { sequence (map (\x -> case x of
+                                 Left l    -> RegionTyParamBound <\$> l
+                                 Right bnd -> TraitTyParamBound <\$> bnd <*> pure None)
+                        $1)
+        }
+
+-- parse_ty_bare_fn(lifetime_defs: Vec<ast::LifetimeDef>)
+ty_bare_fn :: { Spanned [LifetimeDef Span] -> Spanned (Ty Span) }
+ty_bare_fn
+      :  opt(unsafe) opt(then(extern,abi)) fn '(' comma(arg_general) opt('...') ')' ret_ty
+          { \lts -> withSpan $ do
+                      lts' <- lts
+                      unsafety <- maybe (pure Normal) (Unsafe <\$) $1
+                      abi <- maybe (pure Rust) id $2
+                      decl <- withSpan (FnDecl <\$> sequence $5 <*> $8 <*> pure (case $6 of { Nothing -> False; _ -> True }))
+                      pure (BareFn unsafety abi lts' decl)
+          }
+
+-- Sort of like parse_opt_abi() -- currently doesn't handle raw string ABI
+abi :: { Spanned Abi }
+abi   : {- empty -}     { pure C }
+      | str             {% case unspan $1 of
+                             (LiteralTok (StrTok (Name s)) Nothing) | isAbi s -> pure (read s <\$ $1)
+                             _ -> fail "invalid ABI"
+                        }
+
+-- parse_ret_ty
+ret_ty :: { Spanned (Maybe (Ty Span)) }
+ret_ty
+      : {- empty -}     { pure Nothing }
+      | '->' ty         { Just <\$> $2 <* $1 }
+
+-- parse_for_in_type()
+for_in_type :: { Spanned (Ty Span) }
+for_in_type
+      : late_bound_lifetime_defs ty_bare_fn                          { $2 $1 }
+      | late_bound_lifetime_defs trait_ref
+          { let poly = withSpan (PolyTraitRef <\$> $1 <*> $2)
+            in withSpan (PolyTraitRefTy <\$> ((\x -> [x]) <\$> (TraitTyParamBound <\$> poly <*> pure None)))
+          }
+      | late_bound_lifetime_defs trait_ref '+' ty_param_bounds_bare
+          { let poly = withSpan (PolyTraitRef <\$> $1 <*> $2)
+            in withSpan (PolyTraitRefTy <\$> ((:) <\$> (TraitTyParamBound <\$> poly <*> pure None) <*> $4))
+          }
+
+-- no equivalent
+maybe_mut :: { Spanned Mutability }
+maybe_mut
+      : mut                   { Mutable <\$ $1 }
+      | {- empty -} %prec mut { pure Immutable }
+
+-- no equivalent
+maybe_mut_or_const :: { Spanned Mutability }
+maybe_mut_or_const
+      : mut         { Mutable <\$ $1 }
+      | const       { Immutable <\$ $1 }
+      | {- empty -} { pure Immutable }
+
+-- parse_poly_trait_ref()
+poly_trait_ref :: { Spanned (PolyTraitRef Span) }
+poly_trait_ref
+      : late_bound_lifetime_defs trait_ref { withSpan (PolyTraitRef <\$> $1 <*> $2) }
+
+-- parse_late_bound_lifetime_defs()
+late_bound_lifetime_defs :: { Spanned [LifetimeDef Span] }
+late_bound_lifetime_defs
+      : {- empty -}                       { pure [] }
+      | for '<' comma(lifetime_def) '>'   { $1 *> sequence $3 <* $4 } 
+
+-- No corresponding parse function
+lifetime_def :: { Spanned (LifetimeDef Span) }
+lifetime_def
+      : outer_attributes lifetime                           { withSpan (LifetimeDef <\$> $1 <*> $2 <*> pure []) }
+      | outer_attributes lifetime ':' sep_by1(lifetime,'+') { withSpan (LifetimeDef <\$> $1 <*> $2 <*> sequence $4) }
+
+-- parse_lifetime()
+lifetime :: { Spanned (Lifetime Span) }
+lifetime : LIFETIME                                        { let Spanned (LifetimeTok (Ident l _)) s = $1 in Spanned (Lifetime l s) s }
+
+-- parse_trait_ref()
+trait_ref :: { Spanned (TraitRef Span) }
+trait_ref : ty_path                          %prec ident   { withSpan (TraitRef <\$> $1) }
+
+-- no equivalent
+binding :: { Spanned (Ident, Ty Span) }
+binding : ident '=' ty        { (,) <\$> $1 <*> $3  }
+
+
+-- TODO
+
+lit :: { Spanned (Expr Span) }
+lit : {- Unimplemented -}             { error "Unimplemented" }
+
+path_expr :: { Spanned (Expr Span) }
+path_expr : {- Unimplemented -}       { error "Unimplemented" }
+
+ident :: { Spanned Ident }
+ident : IDENT                         { let Spanned (IdentTok i) s = $1 in Spanned i s }
+
+expr :: { Spanned (Expr Span) }
+expr : {- Unimplemented -}            { error "Unimplemented" }
 
 
 {
-  
+
+isPathSegmentIdent :: Ident -> Bool
+isPathSegmentIdent i = True
+
+isTypePathSegmentIdent :: Ident -> Bool
+isTypePathSegmentIdent i = True
+
+isAbi :: InternedString -> Bool
+isAbi s = s `elem` words "Cdecl Stdcall Fastcall Vectorcall Aapcs Win64 SysV64 Rust C System RustIntrinsic RustCall PlatformIntrinsic"
+
+isTraitTyParamBound TraitTyParamBound{} = True
+isTraitTyParamBound _ = False
+ 
+withSpan :: Spanned (Span -> a) -> Spanned a
+withSpan (Spanned f s) = Spanned (f s) s
+
 }

--- a/src/Language/Rust/Parser/Parser2.y
+++ b/src/Language/Rust/Parser/Parser2.y
@@ -24,172 +24,153 @@ import Language.Rust.Syntax.AST
 -- in order to document the parsers, we have to alias them
 %name pat
 
-%tokentype { Spanned Token }
+%tokentype { TokenSpace Spanned }
 
 %monad { P } { >>= } { return }
 %error { parseError }
-%lexer { lexRust } { Spanned Eof _ }
+%lexer { lexRust } { Tok (Spanned Eof _) }
 
 %expect 0
 
 %token
 
   -- Expression-operator symbols. 
-  '='        { Spanned Eq _ }
-  '<'        { Spanned Lt _ }
-  '<='       { Spanned Le _ }
-  '=='       { Spanned EqEq _ }
-  '!='       { Spanned Ne _ }
-  '>='       { Spanned Ge _ }
-  '>'        { Spanned Gt _ }
-  '&&'       { Spanned AndAnd _ }
-  '||'       { Spanned OrOr _ }
-  '!'        { Spanned Exclamation _ }
-  '~'        { Spanned Tilde _ }
+  '='        { Tok $$@(Spanned Equal _) }
+  '<'        { Tok $$@(Spanned Less _) }
+  '>'        { Tok $$@(Spanned Greater _) }
+  '!'        { Tok $$@(Spanned Exclamation _) }
+  '~'        { Tok $$@(Spanned Tilde _) }
   
-  '+'        { Spanned (BinOp Plus) _ }
-  '-'        { Spanned (BinOp Minus) _ }
-  '*'        { Spanned (BinOp Star) _ }
-  '/'        { Spanned (BinOp Slash) _ }
-  '%'        { Spanned (BinOp Percent) _ }
-  '^'        { Spanned (BinOp Caret) _ }
-  '&'        { Spanned (BinOp And) _ }
-  '|'        { Spanned (BinOp Or) _ }
-  '<<'       { Spanned (BinOp Shl) _ }
-  '>>'       { Spanned (BinOp Shr) _ }
-
-  '+='       { Spanned (BinOpEq Plus) _ }
-  '-='       { Spanned (BinOpEq Minus) _ }
-  '*='       { Spanned (BinOpEq Star) _ }
-  '/='       { Spanned (BinOpEq Slash) _ }
-  '%='       { Spanned (BinOpEq Percent) _ }
-  '^='       { Spanned (BinOpEq Caret) _ }
-  '&='       { Spanned (BinOpEq And) _ }
-  '|='       { Spanned (BinOpEq Or) _ }
-  '<<='      { Spanned (BinOpEq Shl) _ }
-  '>>='      { Spanned (BinOpEq Shr) _ }
+  '+'        { Tok $$@(Spanned Plus _) }
+  '-'        { Tok $$@(Spanned Minus _) }
+  '*'        { Tok $$@(Spanned Star _) }
+  '/'        { Tok $$@(Spanned Slash _) }
+  '%'        { Tok $$@(Spanned Percent _) }
+  '^'        { Tok $$@(Spanned Caret _) }
+  '&'        { Tok $$@(Spanned Ampersand _) }
+  '|'        { Tok $$@(Spanned Pipe _) }
 
   -- Structural symbols.
-  '@'        { Spanned At _ }
-  '...'      { Spanned DotDotDot _ }
-  '..'       { Spanned DotDot _ }
-  '.'        { Spanned Dot _ }
-  ','        { Spanned Comma _ }
-  ';'        { Spanned Semicolon _ }
-  '::'       { Spanned ModSep _ }
-  ':'        { Spanned Colon _ }
-  '->'       { Spanned RArrow _ }
-  '<-'       { Spanned LArrow _ }
-  '=>'       { Spanned FatArrow _ }
-  '#'        { Spanned Pound _ }
-  '$'        { Spanned Dollar _ }
-  '?'        { Spanned Question _ }
+  '@'        { Tok $$@(Spanned At _) }
+  '...'      { Tok $$@(Spanned DotDotDot _) }
+  '..'       { Tok $$@(Spanned DotDot _) }
+  '.'        { Tok $$@(Spanned Dot _) }
+  ','        { Tok $$@(Spanned Comma _) }
+  ';'        { Tok $$@(Spanned Semicolon _) }
+  '::'       { Tok $$@(Spanned ModSep _) }
+  ':'        { Tok $$@(Spanned Colon _) }
+  '->'       { Tok $$@(Spanned RArrow _) }
+  '<-'       { Tok $$@(Spanned LArrow _) }
+  '=>'       { Tok $$@(Spanned FatArrow _) }
+  '#'        { Tok $$@(Spanned Pound _) }
+  '$'        { Tok $$@(Spanned Dollar _) }
+  '?'        { Tok $$@(Spanned Question _) }
 
-  '('        { Spanned (OpenDelim Paren) _ }
-  '['        { Spanned (OpenDelim Bracket) _ }
-  '{'        { Spanned (OpenDelim Brace) _ }
-  ')'        { Spanned (CloseDelim Paren) _ }
-  ']'        { Spanned (CloseDelim Bracket) _ }
-  '}'        { Spanned (CloseDelim Brace) _ }
+  '('        { Tok $$@(Spanned (OpenDelim Paren) _) }
+  '['        { Tok $$@(Spanned (OpenDelim Bracket) _) }
+  '{'        { Tok $$@(Spanned (OpenDelim Brace) _) }
+  ')'        { Tok $$@(Spanned (CloseDelim Paren) _) }
+  ']'        { Tok $$@(Spanned (CloseDelim Bracket) _) }
+  '}'        { Tok $$@(Spanned (CloseDelim Brace) _) }
 
   -- Literals.
-  byte       { Spanned (LiteralTok (ByteTok _) _) _ }
-  char       { Spanned (LiteralTok (CharTok _) _) _ }
-  int        { Spanned (LiteralTok (IntegerTok _) _) _ }
-  float      { Spanned (LiteralTok (FloatTok _) _) _ }
-  str        { Spanned (LiteralTok (StrTok _) _) _ }
-  byteStr    { Spanned (LiteralTok (ByteStrTok _) _) _ }
-  rawStr     { Spanned (LiteralTok (StrRawTok _ _) _) _ }
-  rawByteStr { Spanned (LiteralTok (ByteStrRawTok _ _) _) _ }
+  byte       { Tok $$@(Spanned (LiteralTok ByteTok{} _) _) }
+  char       { Tok $$@(Spanned (LiteralTok CharTok{} _) _) }
+  int        { Tok $$@(Spanned (LiteralTok IntegerTok{} _) _) }
+  float      { Tok $$@(Spanned (LiteralTok FloatTok{} _) _) }
+  str        { Tok $$@(Spanned (LiteralTok StrTok{} _) _) }
+  byteStr    { Tok $$@(Spanned (LiteralTok ByteStrTok{} _) _) }
+  rawStr     { Tok $$@(Spanned (LiteralTok StrRawTok{} _) _) }
+  rawByteStr { Tok $$@(Spanned (LiteralTok ByteStrRawTok{} _) _) }
 
   -- Strict keywords used in the language
-  as         { Identifier "as" }
-  box        { Identifier "box" } 
-  break      { Identifier "break" } 
-  const      { Identifier "const" } 
-  continue   { Identifier "continue" }
-  crate      { Identifier "crate" } 
-  else       { Identifier "else" }
-  enum       { Identifier "enum" }
-  extern     { Identifier "extern" }
-  false      { Identifier "false" } 
-  fn         { Identifier "fn" }
-  for        { Identifier "for" } 
-  if         { Identifier "if" }
-  impl       { Identifier "impl" }
-  in         { Identifier "in" }
-  let        { Identifier "let" } 
-  loop       { Identifier "loop" }
-  match      { Identifier "match" } 
-  mod        { Identifier "mod" } 
-  move       { Identifier "move" }
-  mut        { Identifier "mut" } 
-  pub        { Identifier "pub" } 
-  ref        { Identifier "ref" } 
-  return     { Identifier "return" }
-  selftype   { Identifier "self" }
-  selfvalue  { Identifier "Self" } 
-  static     { Identifier "static" }
-  struct     { Identifier "struct" }
-  super      { Identifier "super" } 
-  trait      { Identifier "trait" } 
-  true       { Identifier "true" }
-  type       { Identifier "type" }
-  unsafe     { Identifier "unsafe" }
-  use        { Identifier "use" } 
-  where      { Identifier "where" } 
-  while      { Identifier "while" } 
+  as         { Tok $$@(Identifier "as") }
+  box        { Tok $$@(Identifier "box") } 
+  break      { Tok $$@(Identifier "break") } 
+  const      { Tok $$@(Identifier "const") } 
+  continue   { Tok $$@(Identifier "continue") }
+  crate      { Tok $$@(Identifier "crate") } 
+  else       { Tok $$@(Identifier "else") }
+  enum       { Tok $$@(Identifier "enum") }
+  extern     { Tok $$@(Identifier "extern") }
+  false      { Tok $$@(Identifier "false") } 
+  fn         { Tok $$@(Identifier "fn") }
+  for        { Tok $$@(Identifier "for") } 
+  if         { Tok $$@(Identifier "if") }
+  impl       { Tok $$@(Identifier "impl") }
+  in         { Tok $$@(Identifier "in") }
+  let        { Tok $$@(Identifier "let") } 
+  loop       { Tok $$@(Identifier "loop") }
+  match      { Tok $$@(Identifier "match") } 
+  mod        { Tok $$@(Identifier "mod") } 
+  move       { Tok $$@(Identifier "move") }
+  mut        { Tok $$@(Identifier "mut") } 
+  pub        { Tok $$@(Identifier "pub") } 
+  ref        { Tok $$@(Identifier "ref") } 
+  return     { Tok $$@(Identifier "return") }
+  selftype   { Tok $$@(Identifier "self") }
+  selfvalue  { Tok $$@(Identifier "Self") } 
+  static     { Tok $$@(Identifier "static") }
+  struct     { Tok $$@(Identifier "struct") }
+  super      { Tok $$@(Identifier "super") } 
+  trait      { Tok $$@(Identifier "trait") } 
+  true       { Tok $$@(Identifier "true") }
+  type       { Tok $$@(Identifier "type") }
+  unsafe     { Tok $$@(Identifier "unsafe") }
+  use        { Tok $$@(Identifier "use") } 
+  where      { Tok $$@(Identifier "where") } 
+  while      { Tok $$@(Identifier "while") } 
   
   -- Keywords reserved for future use
-  abstract   { Identifier "abstract" }
-  alignof    { Identifier "alignof" } 
-  become     { Identifier "become" }
-  do         { Identifier "do" }
-  final      { Identifier "final" } 
-  macro      { Identifier "macro" } 
-  offsetof   { Identifier "offsetof" }
-  override   { Identifier "override" }
-  priv       { Identifier "priv" }
-  proc       { Identifier "proc" }
-  pure       { Identifier "pure" }
-  sizeof     { Identifier "sizeof" }
-  typeof     { Identifier "typeof" }
-  unsized    { Identifier "unsized" } 
-  virtual    { Identifier "virtual" } 
-  yield      { Identifier "yield" } 
+  abstract   { Tok $$@(Identifier "abstract") }
+  alignof    { Tok $$@(Identifier "alignof") } 
+  become     { Tok $$@(Identifier "become") }
+  do         { Tok $$@(Identifier "do") }
+  final      { Tok $$@(Identifier "final") } 
+  macro      { Tok $$@(Identifier "macro") } 
+  offsetof   { Tok $$@(Identifier "offsetof") }
+  override   { Tok $$@(Identifier "override") }
+  priv       { Tok $$@(Identifier "priv") }
+  proc       { Tok $$@(Identifier "proc") }
+  pure       { Tok $$@(Identifier "pure") }
+  sizeof     { Tok $$@(Identifier "sizeof") }
+  typeof     { Tok $$@(Identifier "typeof") }
+  unsized    { Tok $$@(Identifier "unsized") } 
+  virtual    { Tok $$@(Identifier "virtual") } 
+  yield      { Tok $$@(Identifier "yield") } 
 
   -- Weak keywords, have special meaning only in specific contexts.
-  default    { Identifier "default" } 
-  staticLife { Identifier "'static" }
-  union      { Identifier "union" } 
+  default    { Tok $$@(Identifier "default") } 
+  staticLife { Tok $$@(Identifier "'static") }
+  union      { Tok $$@(Identifier "union") } 
 
   -- Comments
-  docComment { Spanned (DocComment _) _ }
-  comment    { Spanned Comment _ }
+  -- docComment { Tok $$@(Spanned (DocComment _) _) }
+  -- comment    { Tok $$@(Spanned Comment _) }
 
   -- Types
-  boolTyp    { Identifier "bool" }
-  charTyp    { Identifier "char" }
-  i8Typ      { Identifier "i8" }
-  i16Typ     { Identifier "i16" }
-  i32Typ     { Identifier "i32" }
-  i64Typ     { Identifier "i64" }
-  u8Typ      { Identifier "u8" }
-  u16Typ     { Identifier "u16" }
-  u32Typ     { Identifier "u32" }
-  u64Typ     { Identifier "u64" }
-  isizeTyp   { Identifier "isize" }
-  usizeTyp   { Identifier "usize" }
-  f32Typ     { Identifier "f32" }
-  f64Typ     { Identifier "f64" }
-  strTyp     { Identifier "str" }
+  boolTyp    { Tok $$@(Identifier "bool") }
+  charTyp    { Tok $$@(Identifier "char") }
+  i8Typ      { Tok $$@(Identifier "i8") }
+  i16Typ     { Tok $$@(Identifier "i16") }
+  i32Typ     { Tok $$@(Identifier "i32") }
+  i64Typ     { Tok $$@(Identifier "i64") }
+  u8Typ      { Tok $$@(Identifier "u8") }
+  u16Typ     { Tok $$@(Identifier "u16") }
+  u32Typ     { Tok $$@(Identifier "u32") }
+  u64Typ     { Tok $$@(Identifier "u64") }
+  isizeTyp   { Tok $$@(Identifier "isize") }
+  usizeTyp   { Tok $$@(Identifier "usize") }
+  f32Typ     { Tok $$@(Identifier "f32") }
+  f64Typ     { Tok $$@(Identifier "f64") }
+  strTyp     { Tok $$@(Identifier "str") }
 
   -- Identifiers.
-  ident      { Identifier _ }
-  '_'        { Spanned Underscore _ }
+  ident      { Tok $$@(Identifier _) }
+  '_'        { Tok $$@(Spanned Underscore _) }
 
   -- Lifetimes.
-  lifetime   { Spanned (LifetimeTok _) _ }
+  lifetime   { Tok $$@(Spanned (LifetimeTok _) _) }
 
 -- fake-precedence symbol to cause '|' bars in lambda context to parse
 -- at low precedence, permit things like |x| foo = bar, where '=' is
@@ -260,117 +241,39 @@ import Language.Rust.Syntax.AST
 
 %%
 
-comma_m :: { Bool }
-comma_m
-  : {- Empty -}    { False }
-  | ','            { True }
+-------------
+-- Utility --
+-------------
 
-pat :: { Pat () }
-pat
-  : '_'                                           { WildP () }
-  | '&' pat                                       { RefP $2 Immutable () }
-  | '&' mut pat                                   { RefP $3 Mutable () }
-  | '&&' pat                                      { RefP (RefP $2 Immutable ()) Immutable () }
-  | '&&' mut pat                                  { RefP (RefP $2 Mutable ()) Immutable () }
-  | '(' pats_list_context ')'                     { TupleP (fst $2) (snd $2) () }
-  | '[' pats_list_binding ']'                     { $2 }
-  | lit                                           { LitP $1 () }
-  | '-' lit                                       { LitP (Unary [] Neg $1 ()) () }
-  | path_expr                                     { error "Unimplemented" } {- PathP (Maybe (QSelf a)) (Path a) a -}
-  | lit_or_path '...' lit_or_path                 { RangeP $1 $3 () }
-  | path '{' pat_fields comma_m '}'               { StructP $1 $3 False () }
-  | path '{' pat_fields ',' '..' '}'              { StructP $1 $3 True () }
-  | path '{' '..' '}'                             { StructP $1 [] True () }
-  | path '(' pats_list_context ')'                { TupleStructP $1 (snd $3) (fst $3) () }
-{-  | path '!' maybe_ident delimited_token_trees    { error "Unimplemented" } {- MacP (Mac a) a -} -}
-  | binding_mode ident '@' pat                    { IdentP $1 $2 (Just $4) () }
-  | binding_mode ident                            { IdentP $1 $2 Nothing () }
-  | box pat                                       { BoxP $2 () }
-{- | '<' ty_sum maybe_as_trait_ref '>' '::' ident { $$ = mk_node("PatQualifiedPath", 3, $2, $3, $6); }
-| '<<' ty_sum maybe_as_trait_ref '>' '::' ident maybe_as_trait_ref '>' '::' ident
-{
-  $$ = mk_node("PatQualifiedPath", 3, mk_node("PatQualifiedPath", 3, $2, $3, $6), $7, $10);
-} -}
+-- | Optional parser
+opt(p)          : p                   { Just $1 }
+                |                     { Nothing }
 
-pats_list_context :: { (Maybe Int, [Pat ()]) }
-pats_list_context
-  :                    '..'                              { (Nothing, []) }
-  | comma_pats comma_m                                   { (Nothing, $1) }
-  | comma_pats comma_m '..'                              { (Just (length $1), $1) }
-  |                    '..' comma_m comma_pats comma_m   { (Just 0, $3) }
-  | comma_pats comma_m '..' comma_m comma_pats comma_m   { (Just (length $1), $1 ++ $5) }
+-- | One or more
+some(p)         : rev_list1(p)        { reverse $1 }
 
-pats_list_binding :: { ([Pat a], Maybe (Pat a), [Pat a]) }
-pats_list_binding
-  :                    pat_m '..'                              { SliceP [] $1 [] () }
-  | comma_pats comma_m                                         { SliceP $1 Nothing [] () }
-  | comma_pats comma_m pat_m '..'                              { SliceP $1 $3 [] () }
-  |                    pat_m '..' comma_m comma_pats comma_m   { SliceP [] $1 $4 () }
-  | comma_pats comma_m pat_m '..' comma_m comma_pats comma_m   { SliceP $1 $3 $6 () }
+rev_list1(p)    : p                   { [$1] }
+                | rev_list1(p) p      { $2 : $1 }
 
-pat_m :: { Maybe (Pat ()) }
-pat_m
-  : pat          { Just $1 }
-  | {- Empty -}  { Nothing }
+-- | Zero or more 
+many(p)         : rev_list(p)         { reverse $1 }
 
-pats_or :: { [Pat ()] }
-pats_or : pats_or_rev  { reverse $1 }
+rev_list(p)     : {- Empty -}         { [] }
+                | rev_list(p) p       { $2 : $1 }
 
-pats_or_rev :: { [Pat ()] }
-pats_or_rev
-  : pat              { [$1] }
-  | pats_or '|' pat  { $3 : $1 }
+-- | Zero or more occurrences of p, separated by sep
+sep_by(p,sep)   : {- Empty -}         { [] }
+                | sep_by1(p,sep)      { $1 }
 
-binding_mode :: { BindingMode }
-binding_mode
-  : ref mut     { ByRef Mutable }
-  | ref         { ByRef Immutable }
-  | mut         { ByValue Mutable }
-  | {- Empty -} { ByValue Immutable }
+-- | One or more occurences of p, seperated by sep
+sep_by1(p,sep)  : p many(then(sep,p)) { $1 : $2 }
 
-lit_or_path :: { Expr () }
-lit_or_path
-  : path_expr    { $1 }    {-  PathP (Maybe (QSelf a)) (Path a) a  ?? -}
-  | lit          { $1 }
-  | '-' lit      { Unary [] Neg $2 () }
-
-pat_field :: { FieldPat () }
-pat_field
-  :     binding_mode ident        { FieldPat $2 (IdentP $1 $2 Nothing ()) True () }
-  | box binding_mode ident        { FieldPat $3 (BoxP (IdentP $2 $3 Nothing ()) ()) True () }
-  | binding_mode ident ':' pat    { FieldPat $2 (IdentP $1 $2 (Just $4) ()) True () }
-
-pat_fields :: { [FieldPat ()] }
-pat_fields : pat_fields_rev  { reverse $1 }
-
-pat_fields_rev :: { [FieldPat ()] }
-pat_fields_rev
-  : pat_field                      { [$1] }
-  | pat_fields_rev ',' pat_field   { $3 : $1 }
-
-comma_pats :: { [Pat ()] }
-comma_pats : comma_pats_rev  { reverse $1 }
-
-comma_pats_rev :: { [Pat ()] }
-comma_pats_rev
-  : pat                      { [$1] }
-  | comma_pats_rev ',' pat   { $3 : $1 }
+-- | Sequence two parsers, return the result of the second (*>)
+then(a,b)       : a b                 { $2 }
 
 
-lit :: { Expr () }
-lit : {- Unimplemented -}         { error "Unimplemented" }
 
-path :: { Path () }
-path : {- Unimplemented -}        { error "Unimplemented" }
-
-path_expr :: { Expr () }
-path_expr : {- Unimplemented -}   { error "Unimplemented" }
-
-
-maybe_ident :: { Maybe Ident }
-maybe_ident
-  : {- Empty -}            { Nothing }
-  | ident                  { Just $1 }
+pat : {- Empty -}        { () }
 
 
 

--- a/src/Language/Rust/Parser/Parser2.y
+++ b/src/Language/Rust/Parser/Parser2.y
@@ -31,35 +31,35 @@ import Language.Rust.Syntax.Constants
 %token
 
   -- Expression-operator symbols. 
-  '='        { Tok $$@(Spanned Equal _) }
-  '<'        { Tok $$@(Spanned Less _) }
-  '>'        { Tok $$@(Spanned Greater _) }
-  '!'        { Tok $$@(Spanned Exclamation _) }
-  '~'        { Tok $$@(Spanned Tilde _) }
-  
-  '+'        { Tok $$@(Spanned Plus _) }
-  '-'        { Tok $$@(Spanned Minus _) }
-  '*'        { Tok $$@(Spanned Star _) }
-  '/'        { Tok $$@(Spanned Slash _) }
-  '%'        { Tok $$@(Spanned Percent _) }
-  '^'        { Tok $$@(Spanned Caret _) }
-  '&'        { Tok $$@(Spanned Ampersand _) }
-  '|'        { Tok $$@(Spanned Pipe _) }
-
   EQ         { NoSpTok $$@(Spanned Equal _) }
-  LT         { Tok $$@(Spanned Less _) }
-  GT         { Tok $$@(Spanned Greater _) }
-  NOT        { Tok $$@(Spanned Exclamation _) }
+  LT         { NoSpTok $$@(Spanned Less _) }
+  GT         { NoSpTok $$@(Spanned Greater _) }
+  NOT        { NoSpTok $$@(Spanned Exclamation _) }
+  TILDE      { NoSpTok $$@(Spanned Tilde _) }
   
-  PLUS       { Tok $$@(Spanned Plus _) }
-  MINUS      { Tok $$@(Spanned Minus _) }
-  STAR       { Tok $$@(Spanned Star _) }
-  SLASH      { Tok $$@(Spanned Slash _) }
-  PERCENT    { Tok $$@(Spanned Percent _) }
-  CARET      { Tok $$@(Spanned Caret _) }
-  AMPERSAND  { Tok $$@(Spanned Ampersand _) }
-  PIPE       { Tok $$@(Spanned Pipe _) }
+  PLUS       { NoSpTok $$@(Spanned Plus _) }
+  MINUS      { NoSpTok $$@(Spanned Minus _) }
+  STAR       { NoSpTok $$@(Spanned Star _) }
+  SLASH      { NoSpTok $$@(Spanned Slash _) }
+  PERCENT    { NoSpTok $$@(Spanned Percent _) }
+  CARET      { NoSpTok $$@(Spanned Caret _) }
+  AMPERSAND  { NoSpTok $$@(Spanned Ampersand _) }
+  PIPE       { NoSpTok $$@(Spanned Pipe _) }
 
+  EQ_S       { Tok $$@(Spanned Equal _) }
+  LT_S       { Tok $$@(Spanned Less _) }
+  GT_S       { Tok $$@(Spanned Greater _) }
+  NOT_S      { Tok $$@(Spanned Exclamation _) }
+  TILDE_S    { Tok $$@(Spanned Tilde _) }
+
+  PLUS_S     { Tok $$@(Spanned Plus _) }
+  MINUS_S    { Tok $$@(Spanned Minus _) }
+  STAR_S     { Tok $$@(Spanned Star _) }
+  SLASH_S    { Tok $$@(Spanned Slash _) }
+  PERCENT_S  { Tok $$@(Spanned Percent _) }
+  CARET_S    { Tok $$@(Spanned Caret _) }
+  AMPERSAND_S{ Tok $$@(Spanned Ampersand _) }
+  PIPE_S     { Tok $$@(Spanned Pipe _) }
 
   -- Structural symbols.
   '@'        { Tok $$@(Spanned At _) }
@@ -160,23 +160,6 @@ import Language.Rust.Syntax.Constants
   outerDoc   { Tok $$@(Spanned (Doc _ OuterDoc) _) }
   innerDoc   { Tok $$@(Spanned (Doc _ InnerDoc) _) }
 
-  -- Types
-  boolTyp    { Tok $$@(Identifier "bool") }
-  charTyp    { Tok $$@(Identifier "char") }
-  i8Typ      { Tok $$@(Identifier "i8") }
-  i16Typ     { Tok $$@(Identifier "i16") }
-  i32Typ     { Tok $$@(Identifier "i32") }
-  i64Typ     { Tok $$@(Identifier "i64") }
-  u8Typ      { Tok $$@(Identifier "u8") }
-  u16Typ     { Tok $$@(Identifier "u16") }
-  u32Typ     { Tok $$@(Identifier "u32") }
-  u64Typ     { Tok $$@(Identifier "u64") }
-  isizeTyp   { Tok $$@(Identifier "isize") }
-  usizeTyp   { Tok $$@(Identifier "usize") }
-  f32Typ     { Tok $$@(Identifier "f32") }
-  f64Typ     { Tok $$@(Identifier "f64") }
-  strTyp     { Tok $$@(Identifier "str") }
-
   -- Identifiers.
   IDENT      { Tok $$@(Identifier _) }
   '_'        { Tok $$@(Spanned Underscore _) }
@@ -255,6 +238,22 @@ import Language.Rust.Syntax.Constants
 ---------------------
 -- Extended tokens --
 ---------------------
+
+-- These tokens have both space and no space versions
+'=' : alt(EQ,EQ_S)                { $1 }
+'<' : alt(LT,LT_S)                { $1 }
+'>' : alt(GT,GT_S)                { $1 }
+'!' : alt(NOT,NOT_S)              { $1 }
+'~' : alt(TILDE,TILDE_S)          { $1 }
+
+'+' : alt(PLUS, PLUS_S)           { $1 }
+'-' : alt(MINUS, MINUS_S)         { $1 }
+'*' : alt(STAR, STAR_S)           { $1 }
+'/' : alt(SLASH, SLASH_S)         { $1 }
+'%' : alt(PERCENT, PERCENT_S)     { $1 }
+'^' : alt(CARET, CARET_S)         { $1 }
+'&' : alt(AMPERSAND, AMPERSAND_S) { $1 }
+'|' : alt(PIPE, PIPE_S)           { $1 }
 
 -- All of these have type 'Spanned ()'
 '<<=' : '<' LT EQ      { () <\$ $1 <* $3 }
@@ -359,7 +358,7 @@ qual_path(segs)
 
 -- parse_path(PathStyle::Type)
 ty_path :: { Spanned (Path Span) }
-ty_path 
+ty_path
       : path_segments_without_colons           %prec IDENT { withSpan (Path False <\$> $1) }
       | '::' path_segments_without_colons      %prec IDENT { withSpan (Path True <\$> $2 <* $1) }
 
@@ -382,7 +381,14 @@ path_segments_without_colons : sep_by1(path_segment_without_colons, '::')  { seq
 -- No corresponding function - see path_segments_without_colons
 path_segment_without_colons :: { Spanned (Ident, PathParameters Span) }
 path_segment_without_colons
-      : ident '<' generic_values_after_lt '>'
+      : ident 
+          {% if (not . isTypePathSegmentIdent . unspan \$ $1)
+               then fail "invalid path segment in type path"
+               else pure $ do
+                       i <- $1
+                       pure (i, AngleBracketed [] [] [] mempty)
+          }
+      | ident '<' generic_values_after_lt '>'
           {% if (not . isTypePathSegmentIdent . unspan \$ $1)
                then fail "invalid path segment in type path"
                else pure $ do
@@ -399,14 +405,6 @@ path_segment_without_colons
                       args <- withSpan (Parenthesized <\$> sequence $3 <*> sequence $5 <* $2)
                       pure (i, args)
           }
-      | ident                                
-          {% if (not . isTypePathSegmentIdent . unspan \$ $1)
-               then fail "invalid path segment in type path"
-               else pure $ do
-                       i <- $1
-                       pure (i, AngleBracketed [] [] [] mempty)
-          }
-
 
 -- parse_path_segments_with_colons()
 path_segments_with_colons :: { Spanned [(Ident, PathParameters Span)] }
@@ -475,10 +473,12 @@ generic_values_after_lt
       |                                                      { (pure []    , pure []    , pure []    ) }
 
 -- parse_arg_general(false) -- does not require name
+-- NOT ALL PATTERNS ARE ACCEPTED: <https://github.com/rust-lang/rust/issues/35203>
 arg_general :: { Spanned (Arg Span) } 
 arg_general
-      : arg             { $1 }
-      | ty_sum          { withSpan (Arg <\$> $1 <*> pure (IdentP (ByValue Immutable) invalidIdent Nothing mempty)) }
+      : ty_sum            { withSpan (Arg <\$> $1 <*> pure (IdentP (ByValue Immutable) invalidIdent Nothing mempty)) }
+      | ident ':' ty_sum  { withSpan (Arg <\$> $3 <*> withSpan (IdentP (ByValue Immutable) <\$> $1 <*> pure  Nothing)) }
+      | '_'   ':' ty_sum  { withSpan (Arg <\$> $3 <*> withSpan (WildP <\$ $1)) }
 
 -- parse_arg_general(true) -- requires name
 arg ::{ Spanned (Arg Span) }

--- a/src/Language/Rust/Parser/Parser2.y
+++ b/src/Language/Rust/Parser/Parser2.y
@@ -484,13 +484,13 @@ generic_values_after_lt
 -- NOT ALL PATTERNS ARE ACCEPTED: <https://github.com/rust-lang/rust/issues/35203>
 arg_general :: { Spanned (Arg Span) } 
 arg_general
-      : ty_sum            { withSpan (Arg <\$> $1 <*> pure (IdentP (ByValue Immutable) invalidIdent Nothing mempty)) }
-      | ident ':' ty_sum  { withSpan (Arg <\$> $3 <*> withSpan (IdentP (ByValue Immutable) <\$> $1 <*> pure  Nothing)) }
-      | '_'   ':' ty_sum  { withSpan (Arg <\$> $3 <*> withSpan (WildP <\$ $1)) }
+      : ty_sum            { withSpan (Arg <\$> $1 <*> pure Nothing) }
+      | ident ':' ty_sum  { withSpan (Arg <\$> $3 <*> (Just <\$> withSpan (IdentP (ByValue Immutable) <\$> $1 <*> pure Nothing))) }
+      | '_'   ':' ty_sum  { withSpan (Arg <\$> $3 <*> (Just <\$> withSpan (WildP <\$ $1))) }
 
 -- parse_arg_general(true) -- requires name
 arg ::{ Spanned (Arg Span) }
-arg   : pat ':' ty_sum  { withSpan (Arg <\$> $3 <*> $1) }
+arg   : pat ':' ty_sum  { withSpan (Arg <\$> $3 <*> (Just <\$> $1)) }
 
 
 --------------------------
@@ -614,9 +614,9 @@ lit_or_path
 
 pat_field :: { Spanned (FieldPat Span) }
 pat_field
-      :     binding_mode ident     { withSpan (FieldPat <\$> $2 <*> withSpan (IdentP <\$> $1 <*> $2 <*> pure Nothing) <*> pure True) }
-      | box binding_mode ident     { withSpan (FieldPat <\$> $3 <*> withSpan (BoxP <\$> withSpan (IdentP <\$> $2 <*> $3 <*> pure  Nothing) <* $1) <*> pure True) }
-      | binding_mode ident ':' pat   { withSpan (FieldPat <\$> $2 <*> withSpan (IdentP <\$> $1 <*> $2 <*> (Just <\$> $4)) <*> pure False) }
+      :     binding_mode ident     { withSpan (FieldPat Nothing <\$> withSpan (IdentP <\$> $1 <*> $2 <*> pure Nothing)) }
+      | box binding_mode ident     { withSpan (FieldPat Nothing <\$> withSpan (BoxP <\$> withSpan (IdentP <\$> $2 <*> $3 <*> pure  Nothing) <* $1)) }
+      | binding_mode ident ':' pat   { withSpan (FieldPat <\$> (Just <\$> $2) <*> withSpan (IdentP <\$> $1 <*> $2 <*> (Just <\$> $4))) }
 
 
 -----------

--- a/src/Language/Rust/Pretty.hs
+++ b/src/Language/Rust/Pretty.hs
@@ -359,9 +359,9 @@ printMetaListItem (Literal lit _) = printLiteral lit
 
 -- aka  print_meta_item
 printMetaItem :: MetaItem a -> Doc
-printMetaItem (Word name _) = text name
-printMetaItem (NameValue name lit _) = text name <+> "=" <+> printLiteral lit
-printMetaItem (List name items _) = text name <> "(" <> commas items printMetaListItem <> ")"
+printMetaItem (Word name _) = printIdent name
+printMetaItem (NameValue name lit _) = printIdent name <+> "=" <+> printLiteral lit
+printMetaItem (List name items _) = printIdent name <> "(" <> commas items printMetaListItem <> ")"
 
 -- | Synthesizes a comment that was not textually present in the original source file.
 -- aka  synth_comment

--- a/src/Language/Rust/Pretty.hs
+++ b/src/Language/Rust/Pretty.hs
@@ -294,8 +294,8 @@ printUnOp Neg = "~"
 -- aka print_literal
 -- TODO this is broken with respect to escaping characters
 printLiteral :: Lit a -> Doc
-printLiteral (Str str _ _) = "\"" <> text str <> "\""
-printLiteral (Char c _) = "'" <> text [c] <> "'"
+printLiteral (Str str _ _ _) = "\"" <> text str <> "\""
+{-printLiteral (Char c _) = "'" <> text [c] <> "'"
 printLiteral (Int i _) = text (show i)
 printLiteral (Float str F32 _) = text str <> "f32"
 printLiteral (Float str F64 _) = text str <> "f64"
@@ -303,7 +303,7 @@ printLiteral (FloatUnsuffixed str _) = text str
 printLiteral (Bool True _) = "true"
 printLiteral (Bool False _) = "false"
 printLiteral (ByteStr w8s _) = error "Unimplemented"
-printLiteral (Byte w8 _) = error "Unimplemented"
+printLiteral (Byte w8 _) = error "Unimplemented"-}
 
 -- similar to check_expr_bin_needs_paren
 checkExprBinNeedsParen :: Expr a -> BinOp -> Doc
@@ -349,7 +349,7 @@ printAttribute a@Attribute{..} inline | isSugaredDoc && inline = "/*!" <+> perha
                                       | style == Outer = "#[" <> printMetaItem value <> "]"
 
 valueStr :: Attribute a -> Maybe String
-valueStr (Attribute _ (NameValue _  (Str s _ _) _) _ _) = Just s
+valueStr (Attribute _ (NameValue _  (Str s _ _ _) _) _ _) = Just s
 valueStr _ = Nothing
 
 -- aka  print_meta_list_item

--- a/src/Language/Rust/Syntax/AST.hs
+++ b/src/Language/Rust/Syntax/AST.hs
@@ -799,7 +799,7 @@ data Ty a
   | Rptr (Maybe (Lifetime a)) Mutability (Ty a) a
   -- | A bare function (e.g. fn(usize) -> bool)
   -- Inlined [BareFnTy](-- https://docs.serde.rs/syntex_syntax/ast/struct.BareFnTy.html)
-  | BareFn Unsafety Abi [LifetimeDef a] (FnDecl a) a
+  | BareFn { unsafety :: Unsafety, abi :: Abi, lifetimes :: [LifetimeDef a], decl :: FnDecl a, nodeInfo :: a }
   -- | The never type (!)
   | Never a
   -- | A tuple ((A, B, C, D,...))

--- a/src/Language/Rust/Syntax/AST.hs
+++ b/src/Language/Rust/Syntax/AST.hs
@@ -2,12 +2,12 @@
 
 module Language.Rust.Syntax.AST where
 
-import Language.Rust.Syntax.Token
+import {-# SOURCE #-} Language.Rust.Syntax.Token
 import Language.Rust.Syntax.Ident
 import Language.Rust.Data.Position
 
-import Data.ByteString
-import Data.Word
+import Data.ByteString (ByteString)
+import Data.Word (Word8)
 
 -- https://docs.serde.rs/syntex_syntax/abi/enum.Abi.html
 data Abi
@@ -693,7 +693,7 @@ data Stmt a
 -- https://docs.serde.rs/syntex_syntax/ast/enum.StrStyle.html
 data StrStyle
   = Cooked     -- ^ A regular string, like "foo"
-  | Raw Word64 -- ^ A raw string, like r##"foo"##. The uint is the number of # symbols used
+  | Raw Int    -- ^ A raw string, like r##"foo"##. The uint is the number of # symbols used
 
 -- | Field of a struct. E.g. bar: usize as in struct Foo { bar: usize }
 -- https://docs.serde.rs/syntex_syntax/ast/struct.StructField.html
@@ -723,22 +723,22 @@ data TokenTree
   = Token Span Token
   -- | A delimited sequence of token trees
   -- Inlined [Delimited](https://docs.serde.rs/syntex_syntax/tokenstream/struct.Delimited.html)
-  | Delimited {
-      span :: Span,
-      delim :: DelimToken,       -- ^ The type of delimiter
-      open_span :: Span,         -- ^ The span covering the opening delimiter
-      tts :: [TokenTree],        -- ^ The delimited sequence of token trees
-      close_span :: Span         -- ^ The span covering the closing delimiter
-    }
+  | Delimited
+      { span :: Span 
+      , delim :: DelimToken        -- ^ The type of delimiter
+      , openSpan :: Span           -- ^ The span covering the opening delimiter
+      , tts :: [TokenTree]         -- ^ The delimited sequence of token trees
+      , closeSpan :: Span          -- ^ The span covering the closing delimiter
+      }
   -- | A kleene-style repetition sequence of token trees with a span
   -- Inlined [SequenceRepetition](https://docs.serde.rs/syntex_syntax/tokenstream/struct.SequenceRepetition.html)
-  | Sequence {
-      span :: Span,
-      tts :: [TokenTree],       -- ^ The sequence of token trees
-      separator :: Maybe Token, -- ^ The optional separator
-      op :: KleeneOp,           -- ^ Whether the sequence can be repeated zero (*), or one or more times (+)
-      num_captures :: Int    -- ^ The number of MatchNts that appear in the sequence (and subsequences)
-    }
+  | Sequence 
+      { span :: Span 
+      , tts :: [TokenTree]         -- ^ The sequence of token trees
+      , separator :: Maybe Token   -- ^ The optional separator
+      , op :: KleeneOp             -- ^ Whether the sequence can be repeated zero (*), or one or more times (+)
+      , numCaptures :: Int         -- ^ The number of MatchNts that appear in the sequence (and subsequences)
+      }
 
 -- | A modifier on a bound, currently this is only used for ?Sized, where the modifier is Maybe. Negative
 -- bounds should also be handled here.

--- a/src/Language/Rust/Syntax/AST.hs
+++ b/src/Language/Rust/Syntax/AST.hs
@@ -35,7 +35,7 @@ data Arg a
       { ty :: Ty a
       , pat :: Pat a
       , nodeInfo :: a
-      } deriving (Functor)
+      } deriving (Eq, Show, Functor)
 
 -- | An arm of a 'match'. E.g. `0...10 => { println!("match!") }` as in `match n { 0...10 => { println!("match!") }, /* .. */ }
 -- https://docs.serde.rs/syntex_syntax/ast/struct.Arm.html
@@ -46,11 +46,11 @@ data Arm a
       , guard :: Maybe (Expr a)
       , body :: Expr a
       , nodeInfo :: a
-      } deriving (Functor)
+      } deriving (Eq, Show, Functor)
 
 -- | Inline assembly dialect.
 -- E.g. "intel" as in asm!("mov eax, 2" : "={eax}"(result) : : : "intel")
-data AsmDialect = Att | Intel deriving (Eq, Enum, Bounded)
+data AsmDialect = Att | Intel deriving (Eq, Enum, Bounded, Show)
 
 -- | Doc-comments are promoted to attributes that have isSugaredDoc = true
 -- https://docs.serde.rs/syntex_syntax/ast/struct.Attribute_.html
@@ -60,12 +60,12 @@ data Attribute a
       , value :: MetaItem a
       , isSugaredDoc :: Bool
       , nodeInfo :: a
-      } deriving (Functor)
+      } deriving (Eq, Show, Functor)
 
 -- | Distinguishes between Attributes that decorate items and Attributes that are contained as statements
 -- within items. These two cases need to be distinguished for pretty-printing.
 -- https://docs.serde.rs/syntex_syntax/ast/enum.AttrStyle.html
-data AttrStyle = Outer | Inner deriving (Eq, Enum, Bounded)
+data AttrStyle = Outer | Inner deriving (Eq, Enum, Bounded, Show)
 
 -- https://docs.serde.rs/syntex_syntax/ast/enum.BinOpKind.html
 data BinOp
@@ -87,12 +87,13 @@ data BinOp
   | NeOp     -- ^ The != operator (not equal to)
   | GeOp     -- ^ The >= operator (greater than or equal to)
   | GtOp     -- ^ The > operator (greater than)
-  deriving (Eq, Enum, Bounded)
+  deriving (Eq, Enum, Bounded, Show)
 
 -- https://docs.serde.rs/syntex_syntax/ast/enum.BindingMode.html
 data BindingMode
   = ByRef Mutability
   | ByValue Mutability
+  deriving (Eq, Show)
 
 -- | A Block ({ .. }). E.g. `{ .. }` as in `fn foo() { .. }`
 -- https://docs.serde.rs/syntex_syntax/ast/struct.Block.html
@@ -101,18 +102,18 @@ data Block a
       { stmts :: [Stmt a]       -- ^ Statements in a block
       , rules :: BlockCheckMode -- ^ Distinguishes between `unsafe { ... }` and `{ ... }`
       , nodeInfo :: a
-      } deriving (Functor)
+      } deriving (Eq, Show, Functor)
 
 -- https://docs.serde.rs/syntex_syntax/ast/enum.BlockCheckMode.html
 -- Inlined [UnsafeSource](-- https://docs.serde.rs/syntex_syntax/ast/enum.UnsafeSource.html)
-data BlockCheckMode = DefaultBlock | UnsafeBlock { compilerGenerated :: Bool } deriving (Eq)
+data BlockCheckMode = DefaultBlock | UnsafeBlock { compilerGenerated :: Bool } deriving (Eq, Show)
 
 -- | A capture clause
 -- https://docs.serde.rs/syntex_syntax/ast/enum.CaptureBy.html
-data CaptureBy = Value | Ref deriving (Eq, Enum, Bounded)
+data CaptureBy = Value | Ref deriving (Eq, Enum, Bounded, Show)
 
 -- https://docs.serde.rs/syntex_syntax/ast/enum.Constness.html
-data Constness = Const | NotConst deriving (Eq, Enum, Bounded)
+data Constness = Const | NotConst deriving (Eq, Enum, Bounded, Show)
 
 -- https://docs.serde.rs/syntex_syntax/ast/struct.Crate.html
 data Crate a
@@ -122,14 +123,14 @@ data Crate a
       , config :: MetaItem a
       , exportedMacros :: [MacroDef a]
       , nodeInfo :: a
-      } deriving (Functor)
+      } deriving (Eq, Functor, Show)
 
 -- | The set of MetaItems that define the compilation environment of the crate, used to drive conditional compilation
 -- https://docs.serde.rs/syntex_syntax/ast/type.CrateConfig.html
 type CrateConfig a = [MetaItem a]
 
 -- https://docs.serde.rs/syntex_syntax/ast/enum.Defaultness.html
-data Defaultness = Default | Final deriving (Eq, Enum, Bounded)
+data Defaultness = Default | Final deriving (Eq, Enum, Bounded, Show)
 
 -- | An expression
 -- https://docs.serde.rs/syntex_syntax/ast/struct.Expr.html
@@ -227,7 +228,7 @@ data Expr a
   | ParenExpr [Attribute a] (Expr a) a
   -- | `expr?`
   | Try [Attribute a] (Expr a) a
-  deriving (Functor)
+  deriving (Eq, Functor, Show)
 
 -- https://docs.serde.rs/syntex_syntax/ast/struct.Field.html
 data Field a
@@ -235,7 +236,7 @@ data Field a
       { ident :: Ident
       , expr :: Expr a
       , nodeInfo :: a
-      } deriving (Functor)
+      } deriving (Eq, Functor, Show)
 
 -- A single field in a struct pattern
 -- Patterns like the fields of `Foo { x, ref y, ref mut z }` are treated the same as
@@ -247,10 +248,10 @@ data FieldPat a
       , pat :: Pat a         -- ^ The pattern the field is destructured to
       , isShorthand :: Bool
       , nodeInfo :: a
-      } deriving (Functor)
+      } deriving (Eq, Functor, Show)
 
 -- https://docs.serde.rs/syntex_syntax/ast/enum.FloatTy.html
-data FloatTy = F32 | F64 deriving (Eq, Enum, Bounded)
+data FloatTy = F32 | F64 deriving (Eq, Enum, Bounded, Show)
 
 -- | Header (not the body) of a function declaration.
 -- E.g. `fn foo(bar: baz)`
@@ -264,7 +265,7 @@ data FnDecl a
       , output :: Maybe (Ty a)
       , variadic :: Bool
       , nodeInfo :: a
-      } deriving (Functor)
+      } deriving (Eq, Functor, Show)
 
 -- https://docs.serde.rs/syntex_syntax/ast/struct.ForeignItem.html
 data ForeignItem a
@@ -274,14 +275,14 @@ data ForeignItem a
       , node :: ForeignItemKind a
       , vis :: Visibility a
       , nodeInfo :: a
-      } deriving (Functor)
+      } deriving (Eq, Functor, Show)
 
 -- | An item within an extern block
 -- https://docs.serde.rs/syntex_syntax/ast/enum.ForeignItemKind.html
 data ForeignItemKind a
   = ForeignFn (FnDecl a) (Generics a) -- ^ A foreign function
   | ForeignStatic (Ty a) Bool         -- ^ A foreign static item (static ext: u8), with optional mutability (the boolean is true when mutable)
-  deriving (Functor)
+  deriving (Eq, Functor, Show)
 
 -- | Represents lifetimes and type parameters attached to a declaration of a function, enum, trait, etc.
 -- https://docs.serde.rs/syntex_syntax/ast/struct.Generics.html
@@ -291,7 +292,7 @@ data Generics a
       , tyParams :: [TyParam a]
       , whereClause :: WhereClause a
       , nodeInfo :: a
-      } deriving (Functor)
+      } deriving (Eq, Functor, Show)
 
 -- https://docs.serde.rs/syntex_syntax/ast/struct.ImplItem.html
 data ImplItem a
@@ -302,7 +303,7 @@ data ImplItem a
       , attrs :: [Attribute a]
       , node :: ImplItemKind a
       , nodeInfo :: a
-      } deriving (Functor)
+      } deriving (Eq, Functor, Show)
 
 -- https://docs.serde.rs/syntex_syntax/ast/enum.ImplItemKind.html
 data ImplItemKind a
@@ -310,13 +311,13 @@ data ImplItemKind a
   | MethodI (MethodSig a) (Block a)
   | TypeI (Ty a)
   | MacroI (Mac a)
-  deriving (Functor)
+  deriving (Eq, Functor, Show)
 
 -- https://docs.serde.rs/syntex_syntax/ast/enum.ImplPolarity.html
 data ImplPolarity
   = Positive -- ^ `impl Trait for Type`
   | Negative -- ^ `impl !Trait for Type`
-  deriving (Eq, Enum, Bounded)
+  deriving (Eq, Enum, Bounded, Show)
 
 -- Inline assembly. E.g. `asm!("NOP")`;
 -- https://docs.serde.rs/syntex_syntax/ast/struct.InlineAsm.html
@@ -331,7 +332,7 @@ data InlineAsm a
       , alignstack :: Bool
       , dialect :: AsmDialect
       , nodeInfo :: a
-      } deriving (Functor)
+      } deriving (Eq, Functor, Show)
 
 -- | Inline assembly.
 -- E.g. "={eax}"(result) as in asm!("mov eax, 2" : "={eax}"(result) : : : "intel")`
@@ -342,7 +343,7 @@ data InlineAsmOutput a
       , expr :: Expr a
       , isRw :: Bool
       , isIndirect :: Bool
-      } deriving (Functor)
+      } deriving (Eq, Functor, Show)
 
 -- | An item
 -- The name might be a dummy name in case of anonymous items
@@ -354,7 +355,7 @@ data Item a
       , node :: ItemKind a
       , vis :: Visibility a
       , nodeInfo :: a
-      } deriving (Functor)
+      } deriving (Eq, Functor, Show)
 
 data ItemKind a
   -- | An extern crate item, with optional original crate name.
@@ -404,11 +405,11 @@ data ItemKind a
   -- | A macro invocation (which includes macro definition).
   -- E.g. macro_rules! foo { .. } or foo!(..)
   | MacItem (Mac a)
-  deriving (Functor)
+  deriving (Eq, Functor, Show)
 
 -- | A Kleene-style repetition operator for token sequences.
 -- https://docs.serde.rs/syntex_syntax/tokenstream/enum.KleeneOp.html
-data KleeneOp = ZeroOrMore | OneOrMore deriving (Eq, Enum, Bounded)
+data KleeneOp = ZeroOrMore | OneOrMore deriving (Eq, Enum, Bounded, Show)
 
 -- | A lifetime
 -- https://docs.serde.rs/syntex_syntax/ast/struct.Lifetime.html
@@ -416,7 +417,7 @@ data Lifetime a
   = Lifetime
       { name :: Name
       , nodeInfo :: a
-      } deriving (Functor)
+      } deriving (Eq, Functor, Show)
 
 -- pattern synonym (Static s) = Lifetime (Name "'static") s
 
@@ -428,12 +429,13 @@ data LifetimeDef a
       , lifetime :: Lifetime a
       , bounds :: [Lifetime a]
       , nodeInfo :: a
-      } deriving (Functor)
+      } deriving (Eq, Functor, Show)
 
 -- Merged [LitIntType](https://docs.serde.rs/syntex_syntax/ast/enum.LitIntType.html)
 -- Merged [IntTy](https://docs.serde.rs/syntex_syntax/ast/enum.IntTy.html)
 -- Merged [UintTy](https://docs.serde.rs/syntex_syntax/ast/enum.UintTy.html)
 data Suffix = Unsuffixed | Is | I8 | I16 | I32 | I64 | Us | U8 | U16 |  U32 | U64
+            deriving (Eq, Enum, Bounded)
 
 instance Show Suffix where
   show Unsuffixed = ""
@@ -459,7 +461,7 @@ data Lit a
   | Int Integer Suffix a                    -- ^ An integer (1)
   | Float Double Suffix a                   -- ^ A float literal (1.12e4)
   | Bool Bool Suffix a                      -- ^ A boolean literal
-  deriving (Functor)
+  deriving (Eq, Functor, Show)
 
 -- | Represents a macro invocation. The Path indicates which macro is being invoked, and the vector of
 -- token-trees contains the source of the macro invocation.
@@ -472,13 +474,14 @@ data Mac a
       { path :: Path a
       , tts :: [TokenTree]
       , nodeInfo :: a
-      } deriving (Functor)
+      } deriving (Eq, Functor, Show)
 
 -- https://docs.serde.rs/syntex_syntax/ast/enum.MacStmtStyle.html
 data MacStmtStyle
   = SemicolonMac -- ^ The macro statement had a trailing semicolon, e.g. foo! { ... }; foo!(...);, foo![...];
   | BracesMac    -- ^ The macro statement had braces; e.g. foo! { ... }
   | NoBracesMac  -- ^ The macro statement had parentheses or brackets and no semicolon; e.g. foo!(...). All of these will end up being converted into macro expressions.
+  deriving (Eq, Enum, Bounded, Show)
 
 -- | A macro definition, in this crate or imported from another.
 -- Not parsed directly, but created on macro import or macro_rules! expansion.
@@ -493,7 +496,7 @@ data MacroDef a
       , allowInternalUnstable :: Bool
       , body :: [TokenTree]
       , nodeInfo :: a
-      } deriving (Functor)
+      } deriving (Eq, Functor, Show)
 
 -- | A compile-time attribute item.
 -- E.g. #[test], #[derive(..)] or #[feature = "foo"]
@@ -504,7 +507,7 @@ data MetaItem a
   = Word Ident a                    -- ^ Word meta item.        E.g. test as in #[test]
   | List Ident [NestedMetaItem a] a -- ^ List meta item.        E.g. derive(..) as in #[derive(..)]
   | NameValue Ident (Lit a) a       -- ^ Name value meta item.  E.g. feature = "foo" as in #[feature = "foo"]
-  deriving (Functor)
+  deriving (Eq, Functor, Show)
 
 -- | Represents a method's signature in a trait declaration, or in an implementation.
 -- https://docs.serde.rs/syntex_syntax/ast/struct.MethodSig.html
@@ -515,10 +518,10 @@ data MethodSig a
       , abi :: Abi
       , decl :: FnDecl a
       , generics :: Generics a
-      } deriving (Functor)
+      } deriving (Eq, Functor, Show)
 
 -- https://docs.serde.rs/syntex_syntax/ast/enum.Mutability.html
-data Mutability = Mutable | Immutable deriving (Eq, Enum, Bounded)
+data Mutability = Mutable | Immutable deriving (Eq, Enum, Bounded, Show)
 
 -- | Possible values inside of compile-time attribute lists.
 -- E.g. the '..' in #[name(..)].
@@ -526,7 +529,7 @@ data Mutability = Mutable | Immutable deriving (Eq, Enum, Bounded)
 data NestedMetaItem a
   = MetaItem (MetaItem a) a -- ^ A full MetaItem, for recursive meta items.
   | Literal (Lit a) a      -- ^ A literal. E.g. "foo", 64, true
-  deriving (Functor)
+  deriving (Eq, Functor, Show)
 
 -- | For interpolation during macro expansion.
 -- https://docs.serde.rs/syntex_syntax/parse/token/enum.Nonterminal.html
@@ -547,7 +550,7 @@ data Nonterminal a
   | NtGenerics (Generics a)
   | NtWhereClause (WhereClause a)
   | NtArg (Arg a)
-  deriving (Functor)
+  deriving (Eq, Functor, Show)
 
 -- https://docs.serde.rs/syntex_syntax/ast/struct.Pat.html
 -- Inlined [PatKind][https://docs.serde.rs/syntex_syntax/ast/enum.PatKind.html]
@@ -582,7 +585,7 @@ data Pat a
   | SliceP [Pat a] (Maybe (Pat a)) [Pat a] a
   -- | A macro pattern; pre-expansion
   | MacP (Mac a) a
-  deriving (Functor)
+  deriving (Eq, Functor, Show)
 
 -- | A "Path" is essentially Rust's notion of a name.
 -- It's represented as a sequence of identifiers, along with a bunch of supporting information.
@@ -597,7 +600,7 @@ data Path a
       -- Each segment consists of an identifier, an optional lifetime, and a set of types. E.g. std, String or Box<T>
       , segments :: [(Ident, PathParameters a)]
       , nodeInfo :: a
-      } deriving (Functor)
+      } deriving (Eq, Functor, Show)
 
 -- https://docs.serde.rs/syntex_syntax/ast/type.PathListItem.html
 -- https://docs.serde.rs/syntex_syntax/ast/struct.PathListItem_.html
@@ -606,7 +609,7 @@ data PathListItem a
       { name :: Ident
       , rename :: Maybe Ident -- ^ renamed in list, e.g. `use foo::{bar as baz};`
       , nodeInfo :: a
-      } deriving (Functor)
+      } deriving (Eq, Functor, Show)
 
 -- | Parameters of a path segment.
 -- E.g. <A, B> as in Foo<A, B> or (A, B) as in Foo(A, B)
@@ -628,7 +631,7 @@ data PathParameters a
       , output :: Maybe (Ty a) -- ^ `C`
       , nodeInfo :: a
       }
-  deriving (Functor)
+  deriving (Eq, Functor, Show)
 
 -- https://docs.serde.rs/syntex_syntax/ast/struct.PolyTraitRef.html
 data PolyTraitRef a
@@ -636,7 +639,7 @@ data PolyTraitRef a
       { boundLifetimes :: [LifetimeDef a] -- ^ The `'a` in `<'a> Foo<&'a T>`
       , traitRef :: TraitRef a            -- ^ The `Foo<&'a T>` in `<'a> Foo<&'a T>`
       , nodeInfo :: a
-      } deriving (Functor)
+      } deriving (Eq, Functor, Show)
 
 -- |The explicit Self type in a "qualified path". The actual path, including the trait and the associated item, is stored
 -- separately. position represents the index of the associated item qualified with this Self type.
@@ -653,14 +656,14 @@ data QSelf a
   = QSelf
       { ty :: Ty a
       , position :: Int
-      } deriving (Functor)
+      } deriving (Eq, Functor, Show)
 
 -- | Limit types of a range (inclusive or exclusive)
 -- https://docs.serde.rs/syntex_syntax/ast/enum.RangeLimits.html
 data RangeLimits
   = HalfOpen -- ^ Inclusive at the beginning, exclusive at the end
   | Closed   -- ^ Inclusive at the beginning and end
-  deriving (Eq, Enum, Bounded)
+  deriving (Eq, Enum, Bounded, Show)
 
 -- | Alternative representation for Args describing self parameter of methods.
 -- E.g. &mut self as in fn foo(&mut self)
@@ -669,7 +672,7 @@ data SelfKind a
   = ValueSelf Mutability                    -- ^ self, mut self
   | Region (Maybe (Lifetime a)) Mutability  -- ^ &'lt self, &'lt mut self
   | Explicit (Ty a) Mutability              -- ^ self: TYPE, mut self: TYPE
-  deriving (Functor)
+  deriving (Eq, Functor, Show)
 
 -- | A statement.
 -- https://docs.serde.rs/syntex_syntax/ast/struct.Stmt.html
@@ -688,12 +691,13 @@ data Stmt a
   | NoSemi (Expr a) a    -- ^ Expr without trailing semi-colon.
   | Semi (Expr a) a
   | MacStmt (Mac a) MacStmtStyle [Attribute a] a
-  deriving (Functor)
+  deriving (Eq, Functor, Show)
 
 -- https://docs.serde.rs/syntex_syntax/ast/enum.StrStyle.html
 data StrStyle
   = Cooked     -- ^ A regular string, like "foo"
   | Raw Int    -- ^ A raw string, like r##"foo"##. The uint is the number of # symbols used
+  deriving (Eq, Show)
 
 -- | Field of a struct. E.g. bar: usize as in struct Foo { bar: usize }
 -- https://docs.serde.rs/syntex_syntax/ast/struct.StructField.html
@@ -704,7 +708,7 @@ data StructField a
       , ty :: Ty a
       , attrs :: [Attribute a]
       , nodeInfo :: a
-      } deriving (Functor)
+      } deriving (Eq, Functor, Show)
 
 -- | When the main rust parser encounters a syntax-extension invocation, it parses the arguments to the invocation
 -- as a token-tree. This is a very loose structure, such that all sorts of different AST-fragments can be passed to
@@ -739,10 +743,11 @@ data TokenTree
       , op :: KleeneOp             -- ^ Whether the sequence can be repeated zero (*), or one or more times (+)
       , numCaptures :: Int         -- ^ The number of MatchNts that appear in the sequence (and subsequences)
       }
+  deriving (Eq, Show)
 
 -- | A modifier on a bound, currently this is only used for ?Sized, where the modifier is Maybe. Negative
 -- bounds should also be handled here.
-data TraitBoundModifier = None | Maybe
+data TraitBoundModifier = None | Maybe deriving (Eq, Enum, Bounded, Show)
 
 -- | Represents an item declaration within a trait declaration, possibly including a default implementation.
 -- A trait item is either required (meaning it doesn't have an implementation, just a signature) or provided
@@ -754,7 +759,7 @@ data TraitItem a
       , attrs :: [Attribute a]
       , node :: TraitItemKind a
       , nodeInfo :: a
-      } deriving (Functor)
+      } deriving (Eq, Functor, Show)
 
 -- https://docs.serde.rs/syntex_syntax/ast/enum.TraitItemKind.html
 data TraitItemKind a
@@ -762,7 +767,7 @@ data TraitItemKind a
   | MethodT (MethodSig a) (Maybe (Block a))
   | TypeT [TyParamBound a] (Maybe (Ty a))
   | MacroT (Mac a)
-  deriving (Functor)
+  deriving (Eq, Functor, Show)
 
 -- | TraitRef's appear in impls.
 -- resolve maps each TraitRef's ref_id to its defining trait; that's all that the ref_id is for.
@@ -773,7 +778,7 @@ data TraitRef a
   = TraitRef
       { path :: Path a
       , nodeInfo :: a
-      } deriving (Functor)
+      } deriving (Eq, Functor, Show)
 
 -- | The different kinds of types recognized by the compiler
 -- Inlined [TyKind](https://docs.serde.rs/syntex_syntax/ast/enum.TyKind.html)
@@ -813,7 +818,7 @@ data Ty a
   -- | Inferred type of a self or &self argument in a method.
   | ImplicitSelf a
   | MacTy (Mac a) a
-  deriving (Functor)
+  deriving (Eq, Functor, Show)
 
 -- https://docs.serde.rs/syntex_syntax/ast/struct.TyParam.html
 data TyParam a
@@ -823,7 +828,7 @@ data TyParam a
       , bounds :: [TyParamBound a]
       , default_ :: Maybe (Ty a)
       , nodeInfo :: a
-      } deriving (Functor)
+      } deriving (Eq, Functor, Show)
 
 -- | The AST represents all type param bounds as types. typeck::collect::compute_bounds matches these against the
 -- "special" built-in traits (see middle::lang_items) and detects Copy, Send and Sync.
@@ -831,7 +836,7 @@ data TyParam a
 data TyParamBound a
   = TraitTyParamBound (PolyTraitRef a) TraitBoundModifier
   | RegionTyParamBound (Lifetime a)
-  deriving (Functor)
+  deriving (Eq, Functor, Show)
 
 -- | Parition a list of 'TyParamBound' into a tuple of the 'TraitTyParamBound' and 'RegionTyParamBound' variants.
 partitionTyParamBounds :: [TyParamBound a] -> ([TyParamBound a], [TyParamBound a])
@@ -844,10 +849,10 @@ data UnOp
   = Deref -- ^ The * operator for dereferencing
   | Not   -- ^ the ! operator for logical inversion
   | Neg   -- ^ the - operator for negation
-  deriving (Eq, Enum, Bounded)
+  deriving (Eq, Enum, Bounded, Show)
 
 -- https://docs.serde.rs/syntex_syntax/ast/enum.Unsafety.html
-data Unsafety = Unsafe | Normal deriving (Eq, Enum, Bounded)
+data Unsafety = Unsafe | Normal deriving (Eq, Enum, Bounded, Show)
 
 -- https://docs.serde.rs/syntex_syntax/ast/type.Variant.html
 -- https://docs.serde.rs/syntex_syntax/ast/struct.Variant_.html
@@ -858,7 +863,7 @@ data Variant a
       , data_ :: VariantData a
       , disrExpr :: Maybe (Expr a) -- ^ Explicit discriminant, e.g. Foo = 1
       , nodeInfo :: a
-      } deriving (Functor)
+      } deriving (Eq, Functor, Show)
 
 -- | Fields and Ids of enum variants and structs
 -- 
@@ -867,7 +872,7 @@ data VariantData a
   = StructD [StructField a] a -- ^ Struct variant. E.g. Bar { .. } as in enum Foo { Bar { .. } }
   | TupleD [StructField a] a  -- ^ Tuple variant. E.g. Bar(..) as in enum Foo { Bar(..) }
   | UnitD a                   -- ^ Unit variant. E.g. Bar = .. as in enum Foo { Bar = .. }
-  deriving (Functor)
+  deriving (Eq, Functor, Show)
 
 -- https://docs.serde.rs/syntex_syntax/ast/type.ViewPath.html
 -- https://docs.serde.rs/syntex_syntax/ast/enum.ViewPath_.html
@@ -878,7 +883,7 @@ data ViewPath a
   | ViewPathGlob (Path a) a
   -- | foo::bar::{a,b,c}
   | ViewPathList (Path a) [PathListItem a] a
-  deriving (Functor)
+  deriving (Eq, Functor, Show)
 
 -- https://docs.serde.rs/syntex_syntax/ast/enum.Visibility.html
 data Visibility a
@@ -886,7 +891,7 @@ data Visibility a
   | CrateV
   | RestrictedV (Path a)
   | InheritedV
-  deriving (Functor)
+  deriving (Eq, Functor, Show)
 
 -- | A `where` clause in a definition
 -- https://docs.serde.rs/syntex_syntax/ast/struct.WhereClause.html
@@ -894,7 +899,7 @@ data WhereClause a
   = WhereClause
       { predicates :: [WherePredicate a]
       , nodeInfo :: a
-      } deriving (Functor)
+      } deriving (Eq, Functor, Show)
 
 -- | A single predicate in a where clause
 -- https://docs.serde.rs/syntex_syntax/ast/enum.WherePredicate.html
@@ -921,5 +926,5 @@ data WherePredicate a
       , ty :: Ty a
       , nodeInfo :: a
       }
-  deriving (Functor)
+  deriving (Eq, Functor, Show)
 

--- a/src/Language/Rust/Syntax/AST.hs
+++ b/src/Language/Rust/Syntax/AST.hs
@@ -34,7 +34,7 @@ data Abi
 data Arg a
   = Arg
       { ty :: Ty a
-      , pat :: Pat a
+      , pat :: Maybe (Pat a)
       , nodeInfo :: a
       } deriving (Eq, Show, Functor)
 
@@ -240,14 +240,11 @@ data Field a
       } deriving (Eq, Functor, Show)
 
 -- A single field in a struct pattern
--- Patterns like the fields of `Foo { x, ref y, ref mut z }` are treated the same as
--- `x: x, y: ref y, z: ref mut z`, except `isShorthand` is `true`
 -- https://docs.serde.rs/syntex_syntax/ast/struct.FieldPat.html
 data FieldPat a
   = FieldPat
-      { ident :: Ident       -- ^ The identifier for the field
-      , pat :: Pat a         -- ^ The pattern the field is destructured to
-      , isShorthand :: Bool
+      { ident :: Maybe Ident -- ^ The identifier for the field
+      , pat :: Pat a         -- ^ The pattern the field is destructured to - has to be IdentP when ident is Nothing
       , nodeInfo :: a
       } deriving (Eq, Functor, Show)
 

--- a/src/Language/Rust/Syntax/AST.hs
+++ b/src/Language/Rust/Syntax/AST.hs
@@ -8,6 +8,7 @@ import Language.Rust.Data.Position
 
 import Data.ByteString (ByteString)
 import Data.Word (Word8)
+import Data.List.NonEmpty (NonEmpty(..))
 
 -- https://docs.serde.rs/syntex_syntax/abi/enum.Abi.html
 data Abi
@@ -42,7 +43,7 @@ data Arg a
 data Arm a
   = Arm
       { attrs :: [Attribute a]
-      , pats :: [Pat a] -- NonEmpty
+      , pats :: NonEmpty (Pat a)
       , guard :: Maybe (Expr a)
       , body :: Expr a
       , nodeInfo :: a
@@ -154,7 +155,7 @@ data Expr a
 
   -- Thus, `x.foo::<Bar, Baz>(a, b, c, d)` is represented as
   -- `ExprKind::MethodCall(foo, [Bar, Baz], [x, a, b, c, d])`. -}
-  | MethodCall [Attribute a] Ident [Ty a] [Expr a] a
+  | MethodCall [Attribute a] Ident [Ty a] (NonEmpty (Expr a)) a
   -- |  A tuple (`(a, b, c ,d)`)
   | TupExpr [Attribute a] [Expr a] a
   -- | A binary operation (For example: `a + b`, `a * b`)
@@ -357,7 +358,7 @@ data Item a
 data ItemKind a
   -- | An extern crate item, with optional original crate name.
   -- E.g. extern crate foo or extern crate foo_bar as foo
-  = ExternCrate (Maybe Name)
+  = ExternCrate (Maybe Ident)
   -- | A use declaration (use or pub use) item.
   -- E.g. use foo;, use foo::bar; or use foo::bar as FooBar;
   | Use (ViewPath a)
@@ -810,9 +811,9 @@ data Ty a
   -- | Something like A+B. Note that B must always be a path.
   | ObjectSum (Ty a) [TyParamBound a] a
   -- | A type like for<'a> Foo<&'a Bar>
-  | PolyTraitRefTy [TyParamBound a] a -- NonEmpty
+  | PolyTraitRefTy (NonEmpty (TyParamBound a)) a
   -- | An impl TraitA+TraitB type.
-  | ImplTrait [TyParamBound a] a -- NonEmpty
+  | ImplTrait (NonEmpty (TyParamBound a)) a
   -- | No-op; kept solely so that we can pretty-print faithfully
   | ParenTy (Ty a) a
   -- | Unused for now

--- a/src/Language/Rust/Syntax/AST.hs
+++ b/src/Language/Rust/Syntax/AST.hs
@@ -42,7 +42,7 @@ data Arg a
 data Arm a
   = Arm
       { attrs :: [Attribute a]
-      , pats :: [Pat a]
+      , pats :: [Pat a] -- NonEmpty
       , guard :: Maybe (Expr a)
       , body :: Expr a
       , nodeInfo :: a
@@ -250,9 +250,6 @@ data FieldPat a
       , nodeInfo :: a
       } deriving (Eq, Functor, Show)
 
--- https://docs.serde.rs/syntex_syntax/ast/enum.FloatTy.html
-data FloatTy = F32 | F64 deriving (Eq, Enum, Bounded, Show)
-
 -- | Header (not the body) of a function declaration.
 -- E.g. `fn foo(bar: baz)`
 -- https://docs.serde.rs/syntex_syntax/ast/struct.FnDecl.html
@@ -434,8 +431,13 @@ data LifetimeDef a
 -- Merged [LitIntType](https://docs.serde.rs/syntex_syntax/ast/enum.LitIntType.html)
 -- Merged [IntTy](https://docs.serde.rs/syntex_syntax/ast/enum.IntTy.html)
 -- Merged [UintTy](https://docs.serde.rs/syntex_syntax/ast/enum.UintTy.html)
-data Suffix = Unsuffixed | Is | I8 | I16 | I32 | I64 | Us | U8 | U16 |  U32 | U64
-            deriving (Eq, Enum, Bounded)
+-- Merged [FloatTy](https://docs.serde.rs/syntex_syntax/ast/enum.FloatTy.html)
+data Suffix
+  = Unsuffixed
+  | Is | I8 | I16 | I32 | I64 
+  | Us | U8 | U16 | U32 | U64 
+  |                 F32 | F64
+   deriving (Eq, Enum, Bounded)
 
 instance Show Suffix where
   show Unsuffixed = ""
@@ -449,6 +451,8 @@ instance Show Suffix where
   show U16 = "u16"
   show U32 = "u32"
   show U64 = "u64"
+  show F32 = "f32"
+  show F64 = "f64"
 
 -- | Literal kind.
 -- E.g. "foo", 42, 12.34 or bool
@@ -456,8 +460,8 @@ instance Show Suffix where
 data Lit a
   = Str String StrStyle Suffix a            -- ^ A string ("foo")
   | ByteStr ByteString StrStyle Suffix a    -- ^ A byte string (b"foo")
-  | Byte Word8 Suffix a                     -- ^ A byte (b'f')
   | Char Char Suffix a                      -- ^ A character ('a')
+  | Byte Word8 Suffix a                     -- ^ A byte (b'f')
   | Int Integer Suffix a                    -- ^ An integer (1)
   | Float Double Suffix a                   -- ^ A float literal (1.12e4)
   | Bool Bool Suffix a                      -- ^ A boolean literal
@@ -806,9 +810,9 @@ data Ty a
   -- | Something like A+B. Note that B must always be a path.
   | ObjectSum (Ty a) [TyParamBound a] a
   -- | A type like for<'a> Foo<&'a Bar>
-  | PolyTraitRefTy [TyParamBound a] a
+  | PolyTraitRefTy [TyParamBound a] a -- NonEmpty
   -- | An impl TraitA+TraitB type.
-  | ImplTrait [TyParamBound a] a
+  | ImplTrait [TyParamBound a] a -- NonEmpty
   -- | No-op; kept solely so that we can pretty-print faithfully
   | ParenTy (Ty a) a
   -- | Unused for now
@@ -897,7 +901,7 @@ data Visibility a
 -- https://docs.serde.rs/syntex_syntax/ast/struct.WhereClause.html
 data WhereClause a
   = WhereClause
-      { predicates :: [WherePredicate a]
+      { predicates :: [WherePredicate a] -- NonEmpty?
       , nodeInfo :: a
       } deriving (Eq, Functor, Show)
 

--- a/src/Language/Rust/Syntax/AST.hs
+++ b/src/Language/Rust/Syntax/AST.hs
@@ -6,7 +6,7 @@ import Language.Rust.Syntax.Token
 import Language.Rust.Syntax.Ident
 import Language.Rust.Data.Position
 
-import Data.Int
+import Data.ByteString
 import Data.Word
 
 -- https://docs.serde.rs/syntex_syntax/abi/enum.Abi.html
@@ -433,44 +433,32 @@ data LifetimeDef a
 -- Merged [LitIntType](https://docs.serde.rs/syntex_syntax/ast/enum.LitIntType.html)
 -- Merged [IntTy](https://docs.serde.rs/syntex_syntax/ast/enum.IntTy.html)
 -- Merged [UintTy](https://docs.serde.rs/syntex_syntax/ast/enum.UintTy.html)
-data LitIntType where
-  Unsuffixed :: Show a => a -> LitIntType
-  Is :: Int64 -> LitIntType
-  I8 :: Int8 -> LitIntType
-  I16 :: Int16 -> LitIntType
-  I32 :: Int32 -> LitIntType
-  I64 :: Int64 -> LitIntType
-  Us :: Word64 -> LitIntType
-  U8 :: Word8 -> LitIntType
-  U16 :: Word16 -> LitIntType
-  U32 :: Word32 -> LitIntType
-  U64 :: Word64 -> LitIntType
+data Suffix = Unsuffixed | Is | I8 | I16 | I32 | I64 | Us | U8 | U16 |  U32 | U64
 
-instance Show LitIntType where
-  show (Unsuffixed i) = show i
-  show (Is i) = show i ++ "isize"
-  show (I8 i) = show i ++ "i8"
-  show (I16 i) = show i ++ "i16"
-  show (I32 i) = show i ++ "i32"
-  show (I64 i) = show i ++ "i64"
-  show (Us i) = show i ++ "usize"
-  show (U8 i) = show i ++ "u8"
-  show (U16 i) = show i ++ "u16"
-  show (U32 i) = show i ++ "u32"
-  show (U64 i) = show i ++ "u64"
+instance Show Suffix where
+  show Unsuffixed = ""
+  show Is = "isize"
+  show I8 = "i8"
+  show I16 = "i16"
+  show I32 = "i32"
+  show I64 = "i64"
+  show Us = "usize"
+  show U8 = "u8"
+  show U16 = "u16"
+  show U32 = "u32"
+  show U64 = "u64"
 
 -- | Literal kind.
 -- E.g. "foo", 42, 12.34 or bool
 -- https://docs.serde.rs/syntex_syntax/ast/enum.LitKind.html
 data Lit a
-  = Str InternedString StrStyle a    -- ^ A string literal ("foo")
-  | ByteStr [Word8] a                -- ^ A byte string (b"foo")    TODO: maybe ByteString?
-  | Byte Word8 a                     -- ^ A byte char (b'f')
-  | Char Char a                      -- ^ A character literal ('a')
-  | Int LitIntType a                 -- ^ An integer literal (1)
-  | Float InternedString FloatTy a   -- ^ A float literal (1f64 or 1E10f64)
-  | FloatUnsuffixed InternedString a -- ^ A float literal without a suffix (1.0 or 1.0E10)
-  | Bool Bool a                      -- ^ A boolean literal
+  = Str InternedString StrStyle Suffix a    -- ^ A string ("foo")
+  | ByteStr ByteString StrStyle Suffix a    -- ^ A byte string (b"foo")
+  | Byte Word8 Suffix a                     -- ^ A byte (b'f')
+  | Char Char Suffix a                      -- ^ A character ('a')
+  | Int Integer Suffix a                    -- ^ An integer (1)
+  | Float Double Suffix a                   -- ^ A float literal (1.12e4)
+  | Bool Bool Suffix a                      -- ^ A boolean literal
   deriving (Functor)
 
 -- | Represents a macro invocation. The Path indicates which macro is being invoked, and the vector of
@@ -705,7 +693,7 @@ data Stmt a
 -- https://docs.serde.rs/syntex_syntax/ast/enum.StrStyle.html
 data StrStyle
   = Cooked     -- ^ A regular string, like "foo"
-  | Raw Int    -- ^ A raw string, like r##"foo"##. The uint is the number of # symbols used
+  | Raw Word64 -- ^ A raw string, like r##"foo"##. The uint is the number of # symbols used
 
 -- | Field of a struct. E.g. bar: usize as in struct Foo { bar: usize }
 -- https://docs.serde.rs/syntex_syntax/ast/struct.StructField.html

--- a/src/Language/Rust/Syntax/AST.hs
+++ b/src/Language/Rust/Syntax/AST.hs
@@ -452,7 +452,7 @@ instance Show Suffix where
 -- E.g. "foo", 42, 12.34 or bool
 -- https://docs.serde.rs/syntex_syntax/ast/enum.LitKind.html
 data Lit a
-  = Str InternedString StrStyle Suffix a    -- ^ A string ("foo")
+  = Str String StrStyle Suffix a            -- ^ A string ("foo")
   | ByteStr ByteString StrStyle Suffix a    -- ^ A byte string (b"foo")
   | Byte Word8 Suffix a                     -- ^ A byte (b'f')
   | Char Char Suffix a                      -- ^ A character ('a')
@@ -501,9 +501,9 @@ data MacroDef a
 -- https://docs.serde.rs/syntex_syntax/ast/enum.MetaItemKind.html
 -- https://docs.serde.rs/syntex_syntax/ast/enum.NestedMetaItemKind.html
 data MetaItem a
-  = Word InternedString a                    -- ^ Word meta item.        E.g. test as in #[test]
-  | List InternedString [NestedMetaItem a] a -- ^ List meta item.        E.g. derive(..) as in #[derive(..)]
-  | NameValue InternedString (Lit a) a       -- ^ Name value meta item.  E.g. feature = "foo" as in #[feature = "foo"]
+  = Word Ident a                    -- ^ Word meta item.        E.g. test as in #[test]
+  | List Ident [NestedMetaItem a] a -- ^ List meta item.        E.g. derive(..) as in #[derive(..)]
+  | NameValue Ident (Lit a) a       -- ^ Name value meta item.  E.g. feature = "foo" as in #[feature = "foo"]
   deriving (Functor)
 
 -- | Represents a method's signature in a trait declaration, or in an implementation.

--- a/src/Language/Rust/Syntax/Constants.hs
+++ b/src/Language/Rust/Syntax/Constants.hs
@@ -1,0 +1,94 @@
+module Language.Rust.Syntax.Constants where
+
+import Language.Rust.Syntax.Token
+import Language.Rust.Syntax.Ident
+import Language.Rust.Syntax.AST
+
+import Data.Char
+import Data.Word
+import qualified Data.ByteString.Char8 as BSW (pack)
+import qualified Data.ByteString as BS (pack)
+import Data.List (unfoldr)
+
+-- TODO make this have proper error handling
+parseLit :: LitTok -> Suffix -> a -> Lit a
+parseLit (ByteTok (Name s))         = let Just (w8,"") = unescapeByte s in Byte w8
+parseLit (CharTok (Name s))         = let Just (c,"")  = unescapeChar s in Char c
+parseLit (IntegerTok (Name s))      = Int (unescapeInteger s)  
+parseLit (FloatTok (Name s))        = Float (unescapeFloat s) 
+parseLit (StrTok (Name s))          = Str (unfoldr unescapeChar s) Cooked
+parseLit (StrRawTok (Name s) n)     = Str s (Raw n)
+parseLit (ByteStrTok (Name s))      = ByteStr (BS.pack (unfoldr unescapeByte s)) Cooked
+parseLit (ByteStrRawTok (Name s) n) = ByteStr (BSW.pack s) (Raw n) 
+  
+-- | Given a string of characters read from a Rust source, extract the next underlying char taking
+-- into account escapes and unicode.
+unescapeChar :: String -> Maybe (Char, String)
+unescapeChar ('\\':c:cs) = case c of
+       'n'  -> pure ('\n', cs)
+       'r'  -> pure ('\r', cs)
+       't'  -> pure ('\t', cs)
+       '\\' -> pure ('\\', cs)
+       '\'' -> pure ('\'', cs)
+       '"'  -> pure ('"',  cs)
+       '0'  -> pure ('\0', cs)
+       'x'  -> do (h,cs') <- readHex 2 cs; pure (chr h, cs')
+       'X'  -> do (h,cs') <- readHex 2 cs; pure (chr h, cs')
+       'U'  -> do (h,cs') <- readHex 8 cs; pure (chr h, cs')
+       'u'  -> case cs of
+                 '{':x1:'}':cs'                -> do (h,_)   <- readHex 1 [x1];                pure (chr h, cs')
+                 '{':x1:x2:'}':cs'             -> do (h,_)   <- readHex 2 [x1,x2];             pure (chr h, cs')
+                 '{':x1:x2:x3:'}':cs'          -> do (h,_)   <- readHex 3 [x1,x2,x3];          pure (chr h, cs')
+                 '{':x1:x2:x3:x4:'}':cs'       -> do (h,_)   <- readHex 4 [x1,x2,x3,x4];       pure (chr h, cs')
+                 '{':x1:x2:x3:x4:x5:'}':cs'    -> do (h,_)   <- readHex 5 [x1,x2,x3,x4,x5];    pure (chr h, cs')
+                 '{':x1:x2:x3:x4:x5:x6:'}':cs' -> do (h,_)   <- readHex 6 [x1,x2,x3,x4,x5,x6]; pure (chr h, cs')
+                 _                             -> do (h,cs') <- readHex 4 cs;                  pure (chr h, cs')
+       _    -> error "unescape char: bad escape sequence"
+unescapeChar (c:cs) = Just (c, cs)
+unescapeChar [] = fail "unescape char: empty string"
+
+-- | Given a string of characters read from a Rust source, extract the next underlying byte taking
+-- into account escapes.
+unescapeByte :: String -> Maybe (Word8, String)
+unescapeByte ('\\':c:cs) = case c of
+       'n'  -> pure (toEnum $ fromEnum '\n', cs)
+       'r'  -> pure (toEnum $ fromEnum '\r', cs)
+       't'  -> pure (toEnum $ fromEnum '\t', cs)
+       '\\' -> pure (toEnum $ fromEnum '\\', cs)
+       '\'' -> pure (toEnum $ fromEnum '\'', cs)
+       '"'  -> pure (toEnum $ fromEnum '"',  cs)
+       '0'  -> pure (toEnum $ fromEnum '\0', cs)
+       'x'  -> do (h,cs') <- readHex 2 cs; pure (h, cs')
+       'X'  -> do (h,cs') <- readHex 2 cs; pure (h, cs')
+       _    -> error "unescape byte: bad escape sequence"
+unescapeByte (c:cs) = Just (toEnum $ fromEnum c, cs)
+unescapeByte [] = fail "unescape byte: empty string"
+
+-- | Given a string Rust representation of an integer, parse it into a number
+unescapeInteger :: Num a => String -> a
+unescapeInteger ('0':'b':cs@(_:_)) | all (`elem` "_01") cs = numBase 2 (filter (/= '_') cs)
+unescapeInteger ('0':'o':cs@(_:_)) | all (`elem` "_01234567") cs = numBase 8 (filter (/= '_') cs)
+unescapeInteger ('0':'x':cs@(_:_)) | all (`elem` "_0123456789abcdefABCDEF") cs = numBase 16 (filter (/= '_') cs)
+unescapeInteger cs@(_:_)           | all (`elem` "_0123456789") cs = numBase 10 (filter (/= '_') cs)
+unescapeInteger _ = error "unescape integer: bad decimal literal"
+
+-- | Given a string Rust representation of a float, parse it into a float.
+-- NOTE: this is a bit hacky. Eventually, we might not do this and change the internal
+-- representation of a float to a string (what language-c has opted to do).
+unescapeFloat :: String -> Double
+unescapeFloat cs | last cs == '.' = read (cs ++ "0")
+                 | otherwise = read cs
+
+-- | Try to read a hexadecimal number of the specified length off of the front of the string
+-- provided. If there are not enough characters to do this, or the characters don't fall in the
+-- right range, this fails with 'Nothing'.
+readHex :: Num a => Int -> String -> Maybe (a, String)
+readHex n cs = let digits = take n cs
+               in if length digits == n && all isHexDigit digits
+                    then Just (numBase 16 digits, drop n cs)
+                    else Nothing
+
+-- | Convert a list of characters to the number they represent.
+numBase :: Num a => a -> [Char] -> a
+numBase b cs = foldl (\n x -> fromIntegral (digitToInt x) + b * n) 0 cs
+

--- a/src/Language/Rust/Syntax/Constants.hs
+++ b/src/Language/Rust/Syntax/Constants.hs
@@ -4,8 +4,8 @@ import Language.Rust.Syntax.Token
 import Language.Rust.Syntax.Ident
 import Language.Rust.Syntax.AST
 
-import Data.Char
-import Data.Word
+import Data.Char (chr, isHexDigit, digitToInt)
+import Data.Word (Word8)
 import qualified Data.ByteString.Char8 as BSW (pack)
 import qualified Data.ByteString as BS (pack)
 import Data.List (unfoldr)

--- a/src/Language/Rust/Syntax/Ident.hs
+++ b/src/Language/Rust/Syntax/Ident.hs
@@ -1,9 +1,10 @@
-{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE DuplicateRecordFields, OverloadedStrings #-}
 
 module Language.Rust.Syntax.Ident (Ident(..), name, hash, mkIdent, invalidIdent, Name(..), InternedString) where
 
 import Data.List (foldl')
 import Data.Char (ord)
+import Data.String
 
 -- | An identifier contains a Name (index into the interner table) and a SyntaxContext to track renaming
 -- and macro expansion per Flatt et al., "Macros That Work Together"
@@ -15,6 +16,9 @@ data Ident
       -- ctxt :: SyntaxContext,
       -- nodeInfo :: a
     } deriving (Show)
+
+instance IsString Ident where
+  fromString = mkIdent
 
 instance Eq Ident where
   i1 == i2 = hash i1 == hash i2 && name i1 == name i2

--- a/src/Language/Rust/Syntax/Ident.hs
+++ b/src/Language/Rust/Syntax/Ident.hs
@@ -22,6 +22,9 @@ instance Eq Ident where
 mkIdent :: String -> Ident
 mkIdent s = Ident (Name s) (hashString s) -- 0 ()
 
+unIdent :: Ident -> String
+unIdent (Ident (Name s) _) = s
+
 hashString :: String -> Int
 hashString = foldl' f golden
    where f m c = fromIntegral (ord c) * magic + m

--- a/src/Language/Rust/Syntax/Token.hs
+++ b/src/Language/Rust/Syntax/Token.hs
@@ -64,9 +64,7 @@ data Token
   -- In right-hand-sides of MBE macros:
   | SubstNt Ident IdentStyle                      -- ^ A syntactic variable that will be filled in by macro expansion.
   | SpecialVarNt                                  -- ^ A macro variable with special meaning.
-
-instance Show Token where
-  show _ = error "Token.hs: unimplemented - this instance might belong in Pretty.hs"
+  deriving (Eq, Show)
 
 data DocType = OuterDoc | InnerDoc deriving (Eq, Show, Enum, Bounded)
 data Space = Whitespace | Comment deriving (Eq, Show, Enum, Bounded)

--- a/src/Language/Rust/Syntax/Token.hs
+++ b/src/Language/Rust/Syntax/Token.hs
@@ -39,7 +39,7 @@ data TokenSpace s = TokenSpace (s Token) [s Token]
 -- Inlined https://docs.serde.rs/syntex_syntax/parse/token/enum.BinOpToken.html
 data Token
   -- Single character expression-operator symbols.
-  = Equal | Less | Not | Greater | Ampersand | Pipe | Exclamation | Tilde
+  = Equal | Less | Greater | Ampersand | Pipe | Exclamation | Tilde
   | Plus | Minus | Star | Slash | Percent | Caret 
   -- Structural symbols
   | At | Dot | DotDot | DotDotDot | Comma | Semicolon | Colon | ModSep | RArrow

--- a/src/Language/Rust/Syntax/Token.hs
+++ b/src/Language/Rust/Syntax/Token.hs
@@ -1,8 +1,9 @@
-{-# LANGUAGE DuplicateRecordFields, ExistentialQuantification #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 
 module Language.Rust.Syntax.Token where
 
 import Language.Rust.Syntax.Ident (Ident(..), Name)
+import Language.Rust.Data.Position
 import Language.Rust.Syntax.AST
 
 ------------------
@@ -57,7 +58,7 @@ data Token
   | Eof
   
   -- NOT NEEDED IN TOKENIZATION!!
-  | forall a. Interpolated (Nonterminal a)        -- ^ Can be expanded into several tokens.
+  | Interpolated (Nonterminal Span)               -- ^ Can be expanded into several tokens.
   -- In left-hand-sides of MBE macros:
   | MatchNt Ident Ident IdentStyle IdentStyle     -- ^ Parse a nonterminal (name to bind, name of NT)
   -- In right-hand-sides of MBE macros:

--- a/src/Language/Rust/Syntax/Token.hs
+++ b/src/Language/Rust/Syntax/Token.hs
@@ -63,11 +63,13 @@ data Token
   | SubstNt Ident           -- ^ A syntactic variable that will be filled in by macro expansion.
   | SpecialVarNt            -- ^ A macro variable with special meaning.
   | Space Space Name        -- ^ Whitespace
+  | Doc String DocType      -- ^ Doc comment, contents, whether it is outer or not
   | Shebang
   | Eof
   deriving (Eq, Show)
 
-data Space = Whitespace | DocComment | Comment deriving (Eq, Show, Enum, Bounded)
+data DocType = OuterDoc | InnerDoc deriving (Eq, Show, Enum, Bounded)
+data Space = Whitespace | Comment deriving (Eq, Show, Enum, Bounded)
 
 canBeginExpr :: Token -> Bool
 canBeginExpr OpenDelim{}   = True

--- a/src/Language/Rust/Syntax/Token.hs-boot
+++ b/src/Language/Rust/Syntax/Token.hs-boot
@@ -2,10 +2,16 @@
 
 module Language.Rust.Syntax.Token where
 
-data DelimToken
 data LitTok
 data TokenSpace (s :: * -> *)
+
 data Token
+instance Eq Token
+instance Show Token
+
+data DelimToken
+instance Eq DelimToken
+instance Show DelimToken
 
 data DocType
 data Space

--- a/src/Language/Rust/Syntax/Token.hs-boot
+++ b/src/Language/Rust/Syntax/Token.hs-boot
@@ -1,0 +1,15 @@
+{-# LANGUAGE KindSignatures #-}
+
+module Language.Rust.Syntax.Token where
+
+data DelimToken
+data LitTok
+data TokenSpace (s :: * -> *)
+data Token
+
+data DocType
+data Space
+data IdentStyle
+
+canBeginExpr :: Token -> Bool
+

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-7.9
+resolver: nightly-2016-12-31 
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/tests/LexerTest.hs
+++ b/tests/LexerTest.hs
@@ -72,14 +72,14 @@ commonCode = testGroup "lexing common code fragments"
   , testCode "x /* some comment */ y"
              [ IdentTok (mkIdent "x")
              , Space Whitespace (Name " ")
-             , Space Comment (Name "comment not captured (TODO)")
+             , Space Comment (Name " some comment ")
              , Space Whitespace (Name " ")
              , IdentTok (mkIdent "y")
              ]
   , testCode "x /* some /* nested */ comment */ y"
              [ IdentTok (mkIdent "x")
              , Space Whitespace (Name " ")
-             , Space Comment (Name "comment not captured (TODO)")
+             , Space Comment (Name " some /* nested */ comment ")
              , Space Whitespace (Name " ")
              , IdentTok (mkIdent "y")
              ]

--- a/tests/LexerTest.hs
+++ b/tests/LexerTest.hs
@@ -27,7 +27,7 @@ commonCode = testGroup "lexing common code fragments"
              , Space Whitespace (Name " ")
              , IdentTok (mkIdent "span")
              , Space Whitespace (Name " ")
-             , Eq
+             , Equal
              , Space Whitespace (Name " ")
              , Dollar
              , IdentTok (mkIdent "p")
@@ -44,24 +44,24 @@ commonCode = testGroup "lexing common code fragments"
              , IdentTok (mkIdent "pp")
              , ModSep
              , IdentTok (mkIdent "Printer")
-             , Lt
+             , Less
              , LifetimeTok (mkIdent "a")
-             , Gt
+             , Greater
              , Comma
              ]
   , testCode "impl<'a,T> Tr for &'a T {}"
              [ IdentTok (mkIdent "impl")
-             , Lt
+             , Less
              , LifetimeTok (mkIdent "a")
              , Comma
              , IdentTok (mkIdent "T")
-             , Gt
+             , Greater
              , Space Whitespace (Name " ")
              , IdentTok (mkIdent "Tr")
              , Space Whitespace (Name " ")
              , IdentTok (mkIdent "for")
              , Space Whitespace (Name " ")
-             , BinOp And
+             , Ampersand
              , LifetimeTok (mkIdent "a")
              , Space Whitespace (Name " ")
              , IdentTok (mkIdent "T")
@@ -156,3 +156,4 @@ lexTokensNoSpans inp = runExcept (map unspan <$> tokens)
   where
     tokens :: Except (Position,String) [Spanned Token]
     tokens = execParser lexTokens inp initPos
+

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -4,8 +4,9 @@ import System.IO
 
 import LexerTest (lexerSuite)
 import ParserTest (parserSuite)
+import PrettyTest (prettySuite)
 
 import Test.Framework (Test, defaultMain)
 
 main :: IO ()
-main = hSetEncoding stdout utf8 *> defaultMain [ lexerSuite, parserSuite ]
+main = hSetEncoding stdout utf8 *> defaultMain [ lexerSuite, parserSuite, prettySuite ]

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -3,8 +3,9 @@ module Main where
 import System.IO
 
 import LexerTest (lexerSuite)
+import ParserTest (parserSuite)
 
 import Test.Framework (Test, defaultMain)
 
 main :: IO ()
-main = hSetEncoding stdout utf8 *> defaultMain [ lexerSuite ]
+main = hSetEncoding stdout utf8 *> defaultMain [ lexerSuite, parserSuite ]

--- a/tests/ParserTest.hs
+++ b/tests/ParserTest.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, UnicodeSyntax, FlexibleContexts  #-}
+{-# LANGUAGE OverloadedStrings, OverloadedLists, UnicodeSyntax, FlexibleContexts  #-}
 module ParserTest (parserSuite) where
 
 import Test.Framework (testGroup, Test)
@@ -164,7 +164,7 @@ testPat inp pat = testCase inp $ Right pat @=? parseNoSpans patternP (inputStrea
 
 -- | Turn an InputStream into either an error or a parse.
 parseNoSpans :: Functor f => P (f Span) -> InputStream -> Either (Position,String) (f ())
-parseNoSpans parser inp = runExcept (fmap (const ()) <$> result)
+parseNoSpans parser inp = runExcept (void <$> result)
   where
     -- result :: Except (Position,String) (f Span)
     result = execParser parser inp initPos

--- a/tests/ParserTest.hs
+++ b/tests/ParserTest.hs
@@ -22,21 +22,63 @@ parserSuite = testGroup "parser suite" [ patternSuite, typeSuite, expressionSuit
 patternSuite :: Test
 patternSuite = testGroup "parsing patterns"
   [ testPat "_"                       (WildP ())
-  , testPat "x"                       (IdentP (ByValue Immutable) "x" Nothing ())
-  , testPat "& x"                     (RefP (IdentP (ByValue Immutable) "x" Nothing ()) Immutable ())
-  , testPat "&mut x"                  (RefP (IdentP (ByValue Immutable) "x" Nothing ()) Mutable ())
-  , testPat "(x, ref mut y, box z)"   (TupleP [IdentP (ByValue Immutable) "x" Nothing ()
+  , testPat "x"                       x
+  , testPat "&x"                      (RefP x Immutable ())
+  , testPat "&mut x"                  (RefP x Mutable ())
+  , testPat "(x, ref mut y, box z)"   (TupleP [ x
                                               , IdentP (ByRef Mutable) "y" Nothing ()
                                               , BoxP (IdentP (ByValue Immutable) "z" Nothing ()) ()
                                               ] 
                                               Nothing ())
   , testPat "true"                    (LitP (Lit [] (Bool True Unsuffixed ()) ()) ())
   , testPat "-123"                    (LitP (Unary [] Neg (Lit [] (Int 123 Unsuffixed ()) ()) ()) ())
+  , testPat "Point { .. }"            (StructP (Path False [("Point", AngleBracketed [] [] [] ())] ()) [] True ())
   , testPat "Point { x, y: y1 }"      (StructP (Path False [("Point", AngleBracketed [] [] [] ())] ())
-                                               [ FieldPat "x" (IdentP (ByValue Immutable) "x" Nothing ()) True ()
+                                               [ FieldPat "x" x True ()
                                                , FieldPat "y" (IdentP (ByValue Immutable) "y" (Just (IdentP (ByValue Immutable) "y1" Nothing ())) ()) False () ]
                                                False ()) 
-  ] 
+  , testPat "Point { x, .. }"         (StructP (Path False [("Point", AngleBracketed [] [] [] ())] ())
+                                               [ FieldPat "x" x True () ]
+                                               True ()) 
+  , testPat "math::PI"                (PathP Nothing (Path False [ ("math", AngleBracketed [] [] [] ())
+                                                                 , ("PI", AngleBracketed [] [] [] ()) ] ()) ())
+  , testPat "1...2"                   (RangeP (Lit [] (Int 1 Unsuffixed ()) ()) (Lit [] (Int 2 Unsuffixed ()) ()) ())
+  , testPat "ref mut y@(x,x)"         (IdentP (ByRef Mutable) "y" (Just (TupleP [ x, x ] Nothing ())) ())
+  , testPat "(1,2..3)"                (TupleP [ LitP (Lit [] (Int 1 Unsuffixed ()) ()) ()
+                                              , LitP (Lit [] (Int 2 Unsuffixed ()) ()) ()
+                                              , LitP (Lit [] (Int 3 Unsuffixed ()) ()) () ]
+                                              (Just 2) ())
+  , testPat "(1,2,..,3)"              (TupleP [ LitP (Lit [] (Int 1 Unsuffixed ()) ()) ()
+                                              , LitP (Lit [] (Int 2 Unsuffixed ()) ()) ()
+                                              , LitP (Lit [] (Int 3 Unsuffixed ()) ()) () ]
+                                              (Just 2) ())
+  , testPat "Point(x)"                (TupleStructP (Path False [("Point", AngleBracketed [] [] [] ())] ())
+                                              [ x ] Nothing ())
+  , testPat "<i32 as a(i32, i32)>::b::<'lt>::AssociatedItem"
+            (PathP (Just (QSelf i32 1)) (Path False [ ("a", Parenthesized [i32, i32] Nothing ())
+                                                    , ("b", AngleBracketed [Lifetime (Name "lt") ()] [] [] ())
+                                                    , ("AssociatedItem", AngleBracketed [] [] [] ())
+                                                    ] ()) ())
+  , testPat "[1,2]"                   (SliceP [ LitP (Lit [] (Int 1 Unsuffixed ()) ()) ()
+                                              , LitP (Lit [] (Int 2 Unsuffixed ()) ()) () ] 
+                                              (Just (WildP ())) [] ())
+  , testPat "[1,..,3]"                (SliceP [ LitP (Lit [] (Int 1 Unsuffixed ()) ()) () ]
+                                              (Just (WildP ()))
+                                              [ LitP (Lit [] (Int 3 Unsuffixed ()) ()) () ] ())
+  , testPat "[1,x..,3]"               (SliceP [ LitP (Lit [] (Int 1 Unsuffixed ()) ()) () ]
+                                              (Just x)
+                                              [ LitP (Lit [] (Int 3 Unsuffixed ()) ()) () ] ())
+  , testPat "[1,..]"                  (SliceP [ LitP (Lit [] (Int 1 Unsuffixed ()) ()) () ] (Just (WildP ())) [] ())
+  , testPat "[1,x..]"                 (SliceP [ LitP (Lit [] (Int 1 Unsuffixed ()) ()) () ] (Just x) [] ())
+  ]
+  where
+    -- Just a common pattern to make the tests above more straightforward
+    x :: Pat ()
+    x = IdentP (ByValue Immutable) "x" Nothing ()
+    -- Just a common type to make the tests above more straightforward
+    i32 :: Ty ()
+    i32 = PathTy Nothing (Path False [("i32", AngleBracketed [] [] [] ())] ()) ()
+
 
 -- | This contains tests for parsing a variety of types
 typeSuite :: Test
@@ -68,12 +110,18 @@ typeSuite = testGroup "parsing types"
                                                       , ("Trait", Parenthesized [i32] (Just i32) ())
                                                       , ("AssociatedItem", AngleBracketed [] [] [] ())
                                                       ] ()) ())
+  , testType "fn(i32...)"
+             (BareFn Normal Rust [] (FnDecl [Arg i32 (IdentP (ByValue Immutable) "" Nothing ()) ()] Nothing True ()) ())
   , testType "fn(i32) -> i32"
              (BareFn Normal Rust [] (FnDecl [Arg i32 (IdentP (ByValue Immutable) "" Nothing ()) ()] (Just i32) False ()) ())
   , testType "fn(_: i32) -> i32"
              (BareFn Normal Rust [] (FnDecl [Arg i32 (WildP ()) ()] (Just i32) False ()) ())
   , testType "unsafe extern \"C\" fn(_: i32)"
              (BareFn Unsafe C [] (FnDecl [Arg i32 (WildP ()) ()] Nothing False ()) ())
+  , testType "PResult<'a, P<i32>>"
+             (PathTy Nothing (Path False [("PResult", AngleBracketed [ Lifetime (Name "a") () ]
+                                                                     [ PathTy Nothing (Path False [("P", AngleBracketed [] [ i32 ] [] ())] ()) () ]
+                                                                     [] ())] ()) ())
   , testType "for<'l1: 'l2 + 'l3, 'l4: 'l5> fn(_: i32 + 'l1) -> i32"
              (BareFn Normal Rust
                             [ LifetimeDef [] (Lifetime (Name "l1") ()) [Lifetime (Name "l2") (), Lifetime (Name "l3") ()] ()

--- a/tests/ParserTest.hs
+++ b/tests/ParserTest.hs
@@ -1,0 +1,80 @@
+{-# LANGUAGE OverloadedStrings, UnicodeSyntax, FlexibleContexts  #-}
+module ParserTest (parserSuite) where
+
+import Test.Framework (testGroup, Test)
+import Test.Framework.Providers.HUnit
+import Test.HUnit hiding (Test)
+
+import Language.Rust.Parser.ParseMonad
+import Language.Rust.Parser.Parser2 (expressionP, typeP, patternP)
+import Language.Rust.Syntax.AST
+import Language.Rust.Syntax.Ident
+import Language.Rust.Data.Position
+import Language.Rust.Data.InputStream
+
+import Control.Monad
+import Control.Monad.Trans.Except
+
+parserSuite :: Test
+parserSuite = testGroup "parser suite" [ patternSuite, typeSuite, expressionSuite ]
+
+patternSuite :: Test
+patternSuite = testGroup "parsing patterns"
+  [ testPat "_"                       (WildP ())
+  , testPat "x"                       (IdentP (ByValue Immutable) "x" Nothing ())
+  , testPat "& x"                     (RefP (IdentP (ByValue Immutable) "x" Nothing ()) Immutable ())
+  , testPat "&mut x"                  (RefP (IdentP (ByValue Immutable) "x" Nothing ()) Mutable ())
+  , testPat "(x, ref mut y, box z)"   (TupleP [IdentP (ByValue Immutable) "x" Nothing ()
+                                              , IdentP (ByRef Mutable) "y" Nothing ()
+                                              , BoxP (IdentP (ByValue Immutable) "z" Nothing ()) ()
+                                              ] 
+                                              Nothing ())
+  , testPat "true"                    (LitP (Lit [] (Bool True Unsuffixed ()) ()) ())
+  , testPat "-123"                    (LitP (Unary [] Neg (Lit [] (Int 123 Unsuffixed ()) ()) ()) ())
+  , testPat "Point { x, y: y1 }"      (StructP (Path False [("Point", AngleBracketed [] [] [] ())] ())
+                                               [ FieldPat "x" (IdentP (ByValue Immutable) "x" Nothing ()) True ()
+                                               , FieldPat "y" (IdentP (ByValue Immutable) "y" (Just (IdentP (ByValue Immutable) "y1" Nothing ())) ()) False () ]
+                                               False ()) 
+  ] 
+
+i32 :: Ty ()
+i32 = PathTy Nothing (Path False [("i32", AngleBracketed [] [] [] ())] ()) ()
+
+typeSuite :: Test
+typeSuite = testGroup "parsing types"
+  [ testType "i32"          i32
+  , testType "()"           (TupTy [] ())
+  , testType "(i32,)"       (TupTy [i32] ())
+  , testType "(i32,())"     (TupTy [i32, TupTy [] ()] ())
+  , testType "!"            (Never ())
+  , testType "* i32"        (Ptr Immutable i32 ())
+  , testType "*mut i32"     (Ptr Mutable i32 ())
+  , testType "*const i32"   (Ptr Immutable i32 ())
+  , testType "[i32]"        (Slice i32 ())
+  , testType "[i32; 17]"    (Array i32 (Lit [] (Int 17 Unsuffixed ()) ()) ())
+  , testType "&i32"         (Rptr Nothing Immutable i32 ())
+  , testType "&'lt mut i32" (Rptr (Just (Lifetime (Name "lt") ())) Mutable i32  ())
+  ]
+
+expressionSuite :: Test
+expressionSuite = testGroup "parsing expressions" []
+
+-- | Create a test for a code fragment that should parse to an expression.
+testExpr :: String -> Expr () -> Test
+testExpr inp expr = testCase inp $ Right expr @=? parseNoSpans expressionP (inputStreamFromString inp)
+
+-- | Create a test for a code fragment that should parse to a type.
+testType :: String -> Ty () -> Test
+testType inp ty = testCase inp $ Right ty @=? parseNoSpans typeP (inputStreamFromString inp)
+
+-- | Create a test for a code fragment that should parse to a pattern.
+testPat :: String -> Pat () -> Test
+testPat inp pat = testCase inp $ Right pat @=? parseNoSpans patternP (inputStreamFromString inp)
+
+-- | Turn an InputStream into either an error or a parse.
+parseNoSpans :: Functor f => P (f Span) -> InputStream -> Either (Position,String) (f ())
+parseNoSpans parser inp = runExcept (fmap (const ()) <$> result)
+  where
+    -- result :: Except (Position,String) (f Span)
+    result = execParser parser inp initPos
+

--- a/tests/ParserTest.hs
+++ b/tests/ParserTest.hs
@@ -34,20 +34,16 @@ patternSuite = testGroup "parsing patterns"
   , testPat "-123"                    (LitP (Unary [] Neg (Lit [] (Int 123 Unsuffixed ()) ()) ()) ())
   , testPat "Point { .. }"            (StructP (Path False [("Point", AngleBracketed [] [] [] ())] ()) [] True ())
   , testPat "Point { x, y: y1 }"      (StructP (Path False [("Point", AngleBracketed [] [] [] ())] ())
-                                               [ FieldPat "x" x True ()
-                                               , FieldPat "y" (IdentP (ByValue Immutable) "y" (Just (IdentP (ByValue Immutable) "y1" Nothing ())) ()) False () ]
+                                               [ FieldPat Nothing (IdentP (ByValue Immutable) "x" Nothing ()) ()
+                                               , FieldPat (Just "y") (IdentP (ByValue Immutable) "y1" Nothing ()) () ]
                                                False ()) 
   , testPat "Point { x, .. }"         (StructP (Path False [("Point", AngleBracketed [] [] [] ())] ())
-                                               [ FieldPat "x" x True () ]
-                                               True ()) 
+                                               [ FieldPat Nothing (IdentP (ByValue Immutable)"x" Nothing ()) () ]
+                                               True ())
   , testPat "math::PI"                (PathP Nothing (Path False [ ("math", AngleBracketed [] [] [] ())
                                                                  , ("PI", AngleBracketed [] [] [] ()) ] ()) ())
   , testPat "1...2"                   (RangeP (Lit [] (Int 1 Unsuffixed ()) ()) (Lit [] (Int 2 Unsuffixed ()) ()) ())
   , testPat "ref mut y@(x,x)"         (IdentP (ByRef Mutable) "y" (Just (TupleP [ x, x ] Nothing ())) ())
-  , testPat "(1,2..3)"                (TupleP [ LitP (Lit [] (Int 1 Unsuffixed ()) ()) ()
-                                              , LitP (Lit [] (Int 2 Unsuffixed ()) ()) ()
-                                              , LitP (Lit [] (Int 3 Unsuffixed ()) ()) () ]
-                                              (Just 2) ())
   , testPat "(1,2,..,3)"              (TupleP [ LitP (Lit [] (Int 1 Unsuffixed ()) ()) ()
                                               , LitP (Lit [] (Int 2 Unsuffixed ()) ()) ()
                                               , LitP (Lit [] (Int 3 Unsuffixed ()) ()) () ]
@@ -61,7 +57,7 @@ patternSuite = testGroup "parsing patterns"
                                                     ] ()) ())
   , testPat "[1,2]"                   (SliceP [ LitP (Lit [] (Int 1 Unsuffixed ()) ()) ()
                                               , LitP (Lit [] (Int 2 Unsuffixed ()) ()) () ] 
-                                              (Just (WildP ())) [] ())
+                                              Nothing [] ())
   , testPat "[1,..,3]"                (SliceP [ LitP (Lit [] (Int 1 Unsuffixed ()) ()) () ]
                                               (Just (WildP ()))
                                               [ LitP (Lit [] (Int 3 Unsuffixed ()) ()) () ] ())
@@ -111,13 +107,13 @@ typeSuite = testGroup "parsing types"
                                                       , ("AssociatedItem", AngleBracketed [] [] [] ())
                                                       ] ()) ())
   , testType "fn(i32...)"
-             (BareFn Normal Rust [] (FnDecl [Arg i32 (IdentP (ByValue Immutable) "" Nothing ()) ()] Nothing True ()) ())
+             (BareFn Normal Rust [] (FnDecl [Arg i32 Nothing ()] Nothing True ()) ())
   , testType "fn(i32) -> i32"
-             (BareFn Normal Rust [] (FnDecl [Arg i32 (IdentP (ByValue Immutable) "" Nothing ()) ()] (Just i32) False ()) ())
+             (BareFn Normal Rust [] (FnDecl [Arg i32 Nothing ()] (Just i32) False ()) ())
   , testType "fn(_: i32) -> i32"
-             (BareFn Normal Rust [] (FnDecl [Arg i32 (WildP ()) ()] (Just i32) False ()) ())
+             (BareFn Normal Rust [] (FnDecl [Arg i32 (Just (WildP ())) ()] (Just i32) False ()) ())
   , testType "unsafe extern \"C\" fn(_: i32)"
-             (BareFn Unsafe C [] (FnDecl [Arg i32 (WildP ()) ()] Nothing False ()) ())
+             (BareFn Unsafe C [] (FnDecl [Arg i32 (Just (WildP ())) ()] Nothing False ()) ())
   , testType "PResult<'a, P<i32>>"
              (PathTy Nothing (Path False [("PResult", AngleBracketed [ Lifetime (Name "a") () ]
                                                                      [ PathTy Nothing (Path False [("P", AngleBracketed [] [ i32 ] [] ())] ()) () ]
@@ -126,7 +122,7 @@ typeSuite = testGroup "parsing types"
              (BareFn Normal Rust
                             [ LifetimeDef [] (Lifetime (Name "l1") ()) [Lifetime (Name "l2") (), Lifetime (Name "l3") ()] ()
                             , LifetimeDef [] (Lifetime (Name "l4") ()) [Lifetime (Name "l5") ()] () ]
-                            (FnDecl [Arg (ObjectSum i32 [RegionTyParamBound (Lifetime (Name "l1") ())] ()) (WildP ()) ()] 
+                            (FnDecl [Arg (ObjectSum i32 [RegionTyParamBound (Lifetime (Name "l1") ())] ()) (Just (WildP ())) ()] 
                                     (Just i32) False ()) ())
   , testType "for <'a> Foo<&'a T>"
              (PolyTraitRefTy

--- a/tests/PrettyTest.hs
+++ b/tests/PrettyTest.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE OverloadedStrings #-}
+module PrettyTest (prettySuite) where
+
+import Test.Framework (testGroup, Test)
+import Test.Framework.Providers.HUnit
+import Test.HUnit hiding (Test)
+
+import Language.Rust.Syntax.AST
+import Language.Rust.Syntax.Token
+import Language.Rust.Pretty
+
+import Control.Monad
+import Control.Monad.Trans.Except
+import Text.PrettyPrint (render, Doc)
+
+prettySuite :: Test
+prettySuite = testGroup "pretty suite" [ commonCode, literals ]
+
+-- | This contains some random real-life code fragments. The purpose here is 
+-- primarily black-box testing.
+commonCode :: Test
+commonCode = testGroup "printing common code fragments" []
+
+literals :: Test
+literals = testGroup "printing literals"
+  [ testRender "\"hello world\"" (printLit (Str "hello world" Cooked Unsuffixed ()))
+  , testRender "\"hello \\n w\\x90rld\"" (printLit (Str "hello \n w\x90rld" Cooked Unsuffixed ()))
+  , testRender "123.45f32" (printLit (Float 123.45 F32 ()))
+  , testRender "123isize" (printLit (Int 123 Is ()))
+  , testRender "true" (printLit (Bool True Unsuffixed ()))
+  , testRender "false" (printLit (Bool False Unsuffixed ()))
+  ]
+
+testRender :: String -> Doc -> Test
+testRender str doc = testCase str $ str @=? render doc
+{-
+data Suffix = Unsuffixed | Is | I8 | I16 | I32 | I64 | Us | U8 | U16 |  U32 | U64
+
+Str String StrStyle Suffix a            -- ^ A string ("foo")
+  | ByteStr ByteString StrStyle Suffix a    -- ^ A byte string (b"foo")
+  | Char Char Suffix a                      -- ^ A character ('a')
+  | Byte Word8 Suffix a                     -- ^ A byte (b'f')
+  | Int Integer Suffix a                    -- ^ An integer (1)
+  | Float Double Suffix a                   -- ^ A float literal (1.12e4)
+  | Bool Bool Suffix a             
+  -}

--- a/tests/PrettyTest.hs
+++ b/tests/PrettyTest.hs
@@ -12,10 +12,10 @@ import Language.Rust.Pretty
 
 import Control.Monad
 import Control.Monad.Trans.Except
-import Text.PrettyPrint.Annotated.WL (Doc, flatten, renderPretty, renderPrettyDefault, display)
+import Text.PrettyPrint.Annotated.WL (Doc, flatten, renderPretty, renderPrettyDefault, display, renderCompact)
 
 prettySuite :: Test
-prettySuite = testGroup "pretty suite" [ commonCode, prettyLiterals, prettyTypes ]
+prettySuite = testGroup "pretty suite" [ commonCode, prettyLiterals, prettyTypes, prettyAttributes, prettyExpressions ]
 
 -- | This contains some random real-life code fragments. The purpose here is 
 -- primarily black-box testing.
@@ -112,10 +112,155 @@ prettyTypes = testGroup "printing types"
     lt = RegionTyParamBound (Lifetime (Name "lt") ())
     iterator = TraitTyParamBound (PolyTraitRef [] (TraitRef (Path False [("Iterator", AngleBracketed [] [] [(mkIdent "Item",i32)] ())] ()) ()) ()) None
 
+-- | Test pretty-printing of attributes (flattened).
+prettyAttributes :: Test
+prettyAttributes = testGroup "printing attributes"
+  [ testFlatten "#![cgf]" (printAttr (Attribute Inner (Word (mkIdent "cgf") ()) False ()) True)
+  , testFlatten "#[cgf]" (printAttr (Attribute Outer (Word (mkIdent "cgf") ()) False ()) True)
+  , testFlatten "#[derive(Eq, Ord, 1)]" (printAttr (Attribute Outer (List (mkIdent "derive") 
+                                                        [ MetaItem (Word (mkIdent "Eq") ()) ()
+                                                        , MetaItem (Word (mkIdent "Ord") ()) () 
+                                                        , Literal (Int 1 Unsuffixed ()) ()
+                                                        ] ()) False ()) True)
+  , testFlatten "#[feature = \"foo\"]" (printAttr (Attribute Outer (NameValue (mkIdent "feature") (Str "foo" Cooked Unsuffixed ()) ()) False ()) True)
+  , testFlatten "/*! some comment */" (printAttr (Attribute Outer (NameValue (mkIdent "") (Str "some comment" Cooked Unsuffixed ()) ()) True ()) True)
+  ]
+  
+-- | Test pretty-printing of expressions (flattened). 
+prettyExpressions :: Test
+prettyExpressions = testGroup "printing expressions"
+  [ testFlatten "foo" (printExpr foo) 
+  , testFlatten "bar" (printExpr bar) 
+  , testFlatten "1" (printExpr _1) 
+  , testFlatten "#[cfgo] 2" (printExpr _2) 
+  , testFlatten "box 1" (printExpr (Box [] _1 ()))
+  , testFlatten "#[cfgo] box #[cfgo] 2" (printExpr (Box [cfgO] _2 ()))
+  , testFlatten "#[cfgo] 2 <- 1" (printExpr (InPlace [] _2 _1 ()))
+  , testFlatten "[1, 1, 1]" (printExpr (Vec [] [_1,_1,_1] ()))
+  , testFlatten "#[cfgo] [#![cfgi] #[cfgo] 2, 1, #[cfgo] 2]" (printExpr (Vec [cfgO,cfgI] [_2,_1,_2] ()))
+  , testFlatten "foo(1, bar)" (printExpr (Call [] foo [_1,bar] ()))
+  , testFlatten "foo.method::<i32, f64>(1, bar)" (printExpr (MethodCall [] (mkIdent "method") [i32,f64] [foo,_1,bar] ()))
+  , testFlatten "foo.method(1, bar)" (printExpr (MethodCall [] (mkIdent "method") [] [foo,_1,bar] ()))
+  , testFlatten "()" (printExpr (TupExpr [] [] ()))
+  , testFlatten "#[cfgo] (#![cfgi])" (printExpr (TupExpr [cfgO,cfgI] [] ()))
+  , testFlatten "(1,)" (printExpr (TupExpr [] [_1] ()))
+  , testFlatten "#[cfgo] (#![cfgi] 1,)" (printExpr (TupExpr [cfgO,cfgI] [_1] ()))
+  , testFlatten "(1, foo, bar)" (printExpr (TupExpr [] [_1, foo, bar] ()))
+  , testFlatten "#[cfgo] (#![cfgi] 1, foo, bar)" (printExpr (TupExpr [cfgO, cfgI] [_1, foo, bar] ()))
+  , testFlatten "-foo" (printExpr (Unary [] Neg foo ()))
+  , testFlatten "!foo" (printExpr (Unary [] Not foo ()))
+  , testFlatten "foo + 1" (printExpr (Binary [] AddOp foo _1 ()))
+  , testFlatten "bar * 1" (printExpr (Binary [] MulOp bar _1 ()))
+  , testFlatten "foo + bar * 1" (printExpr (Binary [] AddOp foo (Binary [] MulOp bar _1 ()) ()))
+  , testFlatten "(foo + bar) * 1" (printExpr (Binary [] MulOp (Binary [] AddOp foo bar ()) _1 ()))
+  , testFlatten "1 * (foo + bar)" (printExpr (Binary [] MulOp _1 (Binary [] AddOp foo bar ()) ()))
+  , testFlatten "-1 * (foo + *bar)" (printExpr (Binary [] MulOp (Unary [] Neg _1 ()) (Binary [] AddOp foo (Unary [] Deref bar ()) ()) ()))
+  , testFlatten "foo as i32" (printExpr (Cast [] foo i32 ()))
+  , testFlatten "foo as f64 as i32" (printExpr (Cast [] (Cast [] foo f64 ()) i32 ()))
+  , testFlatten "(foo + 1) as i32" (printExpr (Cast [] (Binary [] AddOp foo _1 ()) i32 ()))
+  , testFlatten "foo: i32" (printExpr (TypeAscription [] foo i32 ()))
+  , testFlatten "if foo { foo = 1 }" (printExpr (If [] foo assBlk Nothing ()))
+  , testFlatten "if foo { foo = 1 } else { return 1; }" (printExpr (If [] foo assBlk (Just (BlockExpr [] retBlk ())) ()))
+  , testFlatten "if foo { foo = 1 } else if bar { return 1; }" (printExpr (If [] foo assBlk (Just (If [] bar retBlk Nothing ())) ()))
+  , testFlatten "if let foo = 1 { return 1; }" (printExpr (IfLet [] (IdentP (ByValue Immutable) (mkIdent "foo") Nothing ()) _1 retBlk Nothing ()))
+  , testFlatten "if let foo = 1 { return 1; } else { return 1; }" (printExpr (IfLet [] (IdentP (ByValue Immutable) (mkIdent "foo") Nothing ()) _1 retBlk (Just (BlockExpr [] retBlk ())) ()))
+  , testFlatten "while foo { foo = 1 }" (printExpr (While [] foo assBlk Nothing ()))
+  , testFlatten "'lbl: while foo { foo = 1 }" (printExpr (While [] foo assBlk (Just (mkIdent "'lbl")) ()))
+  , testFlatten "#[cfgo] while foo { #![cfgi] foo = 1 }" (printExpr (While [cfgI,cfgO] foo assBlk Nothing ()))
+  , testFlatten "while let foo = 1 { foo = 1 }" (printExpr (WhileLet [] (IdentP (ByValue Immutable) (mkIdent "foo") Nothing ()) _1 assBlk Nothing ()))
+  , testFlatten "'lbl: while let foo = 1 { foo = 1 }" (printExpr (WhileLet [] (IdentP (ByValue Immutable) (mkIdent "foo") Nothing ()) _1 assBlk (Just (mkIdent "'lbl")) ()))
+  , testFlatten "#[cfgo] while let foo = 1 { #![cfgi] foo = 1 }" (printExpr (WhileLet [cfgO,cfgI] (IdentP (ByValue Immutable) (mkIdent "foo") Nothing ()) _1 assBlk Nothing ()))
+  , testFlatten "for foo in bar { foo = 1 }" (printExpr (ForLoop [] (IdentP (ByValue Immutable) (mkIdent "foo") Nothing ()) bar assBlk Nothing ()))
+  , testFlatten "'lbl: for foo in bar { foo = 1 }" (printExpr (ForLoop [] (IdentP (ByValue Immutable) (mkIdent "foo") Nothing ()) bar assBlk (Just (mkIdent "'lbl")) ()))
+  , testFlatten "#[cfgo] for foo in bar { #![cfgi] foo = 1 }" (printExpr (ForLoop [cfgO,cfgI] (IdentP (ByValue Immutable) (mkIdent "foo") Nothing ()) bar assBlk Nothing ()))
+  , testFlatten "loop { foo = 1 }" (printExpr (Loop [] assBlk Nothing ()))
+  , testFlatten "'lbl: loop { foo = 1 }" (printExpr (Loop [] assBlk (Just (mkIdent "'lbl")) ()))
+  , testFlatten "#[cfgo] loop { #![cfgi] foo = 1 }" (printExpr (Loop [cfgO,cfgI] assBlk Nothing ()))
+  , testFlatten "match foo { }" (printExpr (Match [] foo [] ())) 
+  , testFlatten "match foo { _ => 1 }" (printExpr (Match [] foo [Arm [] [WildP ()] Nothing _1 ()] ())) 
+  , testFlatten "#[cfgo] match foo { #![cfgi] _ => 1 }" (printExpr (Match [cfgI,cfgO] foo [Arm [] [WildP ()] Nothing _1 ()] ())) 
+  , testFlatten "match foo { _ => { return 1; } }" (printExpr (Match [] foo [Arm [] [WildP ()] Nothing (BlockExpr [] retBlk ()) ()] ())) 
+  , testFlatten "match foo { _ => { return 1; } _ | _ if foo => 1 }" (printExpr (Match [] foo [Arm [] [WildP ()] Nothing (BlockExpr [] retBlk ()) (), Arm [] [WildP (), WildP ()] (Just foo) _1 ()] ())) 
+  , testFlatten "move |x: i32| { return 1; }"
+                (printExpr (Closure [] Value (FnDecl [Arg i32 (IdentP (ByValue Immutable) (mkIdent "x") Nothing ()) ()] Nothing False ()) 
+                                    retBlk ()))
+  , testFlatten "|x: i32| -> i32 { return 1; }"
+                (printExpr (Closure [] Ref (FnDecl [Arg i32 (IdentP (ByValue Immutable) (mkIdent "x") Nothing ()) ()] (Just i32) False ()) 
+                                    retBlk ()))
+  , testFlatten "#[cfgo] { #![cfgi] return 1; }" (printExpr (BlockExpr [cfgI,cfgO] retBlk ()))
+  , testFlatten "{ return 1; }" (printExpr (BlockExpr [] retBlk ()))
+  , testFlatten "foo = 1" (printExpr (Assign [] foo _1 ()))
+  , testFlatten "foo += 1" (printExpr (AssignOp [] AddOp foo _1 ()))
+  , testFlatten "foo <<= 1" (printExpr (AssignOp [] ShlOp foo _1 ()))
+  , testFlatten "foo.bar" (printExpr (FieldAccess [] foo (mkIdent "bar") ()))
+  , testFlatten "foo.1" (printExpr (TupField [] foo 1 ()))
+  , testFlatten "foo[1]" (printExpr (Index [] foo _1 ()))
+  , testFlatten "foo..bar" (printExpr (Range [] (Just foo) (Just bar) HalfOpen ()))
+  , testFlatten "foo..." (printExpr (Range [] (Just foo) Nothing Closed ()))
+  , testFlatten "..bar" (printExpr (Range [] Nothing (Just bar) HalfOpen ()))
+  , testFlatten "..." (printExpr (Range [] Nothing Nothing Closed ()))
+  , testFlatten "std::vec::Vec::<i32>" (printExpr (PathExpr [] Nothing (Path False [ std, vec, veci32 ] ()) ()))
+  , testFlatten "<i32 as std::vec>::Vec::<i32>" (printExpr (PathExpr [] (Just (QSelf i32 2)) (Path False [ std, vec, veci32 ] ()) ()))
+  , testFlatten "&foo" (printExpr (AddrOf [] Immutable foo ()))
+  , testFlatten "#[cfgo] &mut foo" (printExpr (AddrOf [cfgO] Mutable foo ()))
+  , testFlatten "break" (printExpr (Break [] Nothing ()))
+  , testFlatten "break 'foo" (printExpr (Break [] (Just (mkIdent "'foo")) ()))
+  , testFlatten "continue" (printExpr (Continue [] Nothing ()))
+  , testFlatten "continue 'foo" (printExpr (Continue [] (Just (mkIdent "'foo")) ()))
+  , testFlatten "return" (printExpr (Ret [] Nothing ()))
+  , testFlatten "return foo" (printExpr (Ret [] (Just foo) ()))
+  , testFlatten "#[cfgo] asm!(\"mov eax, 2\" : \"={eax}\"(foo) : \"{dx}\"(bar) : \"eax\" : \"volatile\", \"alignstack\")"
+                (printExpr (InlineAsmExpr [cfgO] (InlineAsm "mov eax, 2" Cooked [InlineAsmOutput "={eax}" foo False False]
+                                                            [("{dx}",bar)] ["eax"] True True Att ()) ()))
+  , testFlatten "asm!(\"mov eax, 2\" : \"={eax}\"(foo) : : : \"intel\")"
+                (printExpr (InlineAsmExpr [] (InlineAsm "mov eax, 2" Cooked [InlineAsmOutput "={eax}" foo False False] []
+                                                        [] False False Intel ()) ()))
+  , testFlatten "print!(foo)" (printExpr (MacExpr [] (Mac (Path False [("print", AngleBracketed [] [] [] ())] ())
+                                       [ Token mempty (IdentTok (mkIdent "foo")) ] ()) ()))
+  , testFlatten "foo { }" (printExpr (Struct [] (Path False [("foo", AngleBracketed [] [] [] ())] ()) [] Nothing ()))
+  , testFlatten "foo { x: 1 }" (printExpr (Struct [] (Path False [("foo", AngleBracketed [] [] [] ())] ()) [Field (mkIdent "x") _1 ()] Nothing ()))
+  , testFlatten "#[cfgo] foo { #![cfgi] x: 1 }" (printExpr (Struct [cfgO,cfgI] (Path False [("foo", AngleBracketed [] [] [] ())] ()) [Field (mkIdent "x") _1 ()] Nothing ()))
+  , testFlatten "foo { x: 1, y: 1 }" (printExpr (Struct [] (Path False [("foo", AngleBracketed [] [] [] ())] ()) [Field (mkIdent "x") _1 (), Field (mkIdent "y") _1 ()] Nothing ()))
+  , testFlatten "foo { x: 1, y: 1, ..bar }" (printExpr (Struct [] (Path False [("foo", AngleBracketed [] [] [] ())] ()) [Field (mkIdent "x") _1 (), Field (mkIdent "y") _1 ()] (Just bar) ()))
+  , testFlatten "#[cfgo] foo { #![cfgi] x: 1, y: 1, ..bar }" (printExpr (Struct [cfgO,cfgI] (Path False [("foo", AngleBracketed [] [] [] ())] ()) [Field (mkIdent "x") _1 (), Field (mkIdent "y") _1 ()] (Just bar) ()))
+  , testFlatten "[foo; 1]" (printExpr (Repeat [] foo _1 ()))
+  , testFlatten "#[cfgo] [#![cfgi] foo; 1]" (printExpr (Repeat [cfgI, cfgO] foo _1 ()))
+  , testFlatten "(foo?)" (printExpr (ParenExpr [] (Try [] foo ()) ()))
+  , testFlatten "foo?" (printExpr (Try [] foo ()))
+  ]
+  where
+    -- Literal expressionsi
+    _1, _2, foo, bar :: Expr ()
+    _1 = Lit [] (Int 1 Unsuffixed ()) ()
+    _2 = Lit [cfgO] (Int 2 Unsuffixed ()) ()
+    foo = PathExpr [] Nothing (Path False [("foo", AngleBracketed [] [] [] ())] ()) ()
+    bar = PathExpr [] Nothing (Path False [("bar", AngleBracketed [] [] [] ())] ()) ()
+
+    -- Attributes
+    cfgI, cfgO :: Attribute ()
+    cfgI = Attribute Inner (Word (mkIdent "cfgi") ()) False ()
+    cfgO = Attribute Outer (Word (mkIdent "cfgo") ()) False ()
+
+    -- Types
+    i32, f64 :: Ty ()
+    i32 = PathTy Nothing (Path False [("i32", AngleBracketed [] [] [] ())] ()) ()
+    f64 = PathTy Nothing (Path False [("f64", AngleBracketed [] [] [] ())] ()) ()
+    
+    -- Path segments
+    std = ("std", AngleBracketed [] [] [] ())
+    vec = ("vec", AngleBracketed [] [] [] ())
+    veci32 = ("Vec", AngleBracketed [] [i32] [] ())
+    debug = ("Debug", AngleBracketed [] [] [] ())
+
+    -- Blocks
+    assBlk = Block [ NoSemi (Assign [] foo _1 ()) () ] DefaultBlock ()
+    retBlk = Block [ Semi (Ret [] (Just _1) ()) () ] DefaultBlock ()
+
+
 testRender :: String -> Doc a -> Test
 testRender str doc = testCase str $ str @=? display (renderPrettyDefault doc)
 
 testFlatten :: String -> Doc a -> Test
-testFlatten str doc = testCase str $ str @=? display (renderPrettyDefault (flatten doc))
+testFlatten str doc = testCase str $ str @=? display (renderPretty 0.5 1000 (flatten doc))
 
 

--- a/tests/PrettyTest.hs
+++ b/tests/PrettyTest.hs
@@ -7,40 +7,115 @@ import Test.HUnit hiding (Test)
 
 import Language.Rust.Syntax.AST
 import Language.Rust.Syntax.Token
+import Language.Rust.Syntax.Ident
 import Language.Rust.Pretty
 
 import Control.Monad
 import Control.Monad.Trans.Except
-import Text.PrettyPrint.Annotated.WL (Doc)
+import Text.PrettyPrint.Annotated.WL (Doc, flatten, renderPretty, renderPrettyDefault, display)
 
 prettySuite :: Test
-prettySuite = testGroup "pretty suite" [ commonCode, literals ]
+prettySuite = testGroup "pretty suite" [ commonCode, prettyLiterals, prettyTypes ]
 
 -- | This contains some random real-life code fragments. The purpose here is 
 -- primarily black-box testing.
 commonCode :: Test
 commonCode = testGroup "printing common code fragments" []
 
-literals :: Test
-literals = testGroup "printing literals"
-  [ testRender "\"hello world\"" (printLit (Str "hello world" Cooked Unsuffixed ()))
-  , testRender "\"hello \\n w\\x90rld\"" (printLit (Str "hello \n w\x90rld" Cooked Unsuffixed ()))
-  , testRender "123.45f32" (printLit (Float 123.45 F32 ()))
-  , testRender "123isize" (printLit (Int 123 Is ()))
-  , testRender "true" (printLit (Bool True Unsuffixed ()))
-  , testRender "false" (printLit (Bool False Unsuffixed ()))
+-- | White-box testing of literals, especially character encoding/escapes.
+prettyLiterals :: Test
+prettyLiterals = testGroup "printing literals"
+  [ testFlatten "b\"hello world\"" (printLit (ByteStr "hello world" Cooked Unsuffixed ()))
+  , testFlatten "br###\"hello #\"# world\"###" (printLit (ByteStr "hello #\"# world" (Raw 3) Unsuffixed ()))
+  , testFlatten "b\"hello \\n w\\x90rld\"" (printLit (ByteStr "hello \n w\x90rld" Cooked Unsuffixed ()))
+  , testFlatten "\"hello world\"" (printLit (Str "hello world" Cooked Unsuffixed ()))
+  , testFlatten "r###\"hello #\"# world\"###" (printLit (Str "hello #\"# world" (Raw 3) Unsuffixed ()))
+  , testFlatten "\"hello \\n w\\x90\\U00012345rld\"" (printLit (Str "hello \n w\x90\74565rld" Cooked Unsuffixed ()))
+  , testFlatten "'f'" (printLit (Char 'f' Unsuffixed ()))
+  , testFlatten "'\\t'" (printLit (Char '\t' Unsuffixed ()))
+  , testFlatten "'\\x81'" (printLit (Char '\129' Unsuffixed ()))
+  , testFlatten "'\\u0123'" (printLit (Char '\291' Unsuffixed ()))
+  , testFlatten "'\\U00012345'" (printLit (Char '\74565' Unsuffixed ()))
+  , testFlatten "b'f'" (printLit (Byte 102 Unsuffixed ()))
+  , testFlatten "b'\\t'" (printLit (Byte 9 Unsuffixed ()))
+  , testFlatten "b'\\x81'" (printLit (Byte 129 Unsuffixed ()))
+  , testFlatten "123.45f32" (printLit (Float 123.45 F32 ()))
+  , testFlatten "123.45f64" (printLit (Float 123.45 F64 ()))
+  , testFlatten "123" (printLit (Int 123 Unsuffixed ()))
+  , testFlatten "123isize" (printLit (Int 123 Is ()))
+  , testFlatten "-12i8" (printLit (Int (-12) I8 ()))
+  , testFlatten "123456u64" (printLit (Int 123456 U64 ()))
+  , testFlatten "123isize" (printLit (Int 123 Is ()))
+  , testFlatten "false" (printLit (Bool False Unsuffixed ()))
+  , testFlatten "true" (printLit (Bool True Unsuffixed ()))
   ]
 
-testRender :: String -> Doc a -> Test
-testRender str doc = testCase str $ str @=? show doc
-{-
-data Suffix = Unsuffixed | Is | I8 | I16 | I32 | I64 | Us | U8 | U16 |  U32 | U64
+-- | Test pretty-printing of types (flattened). 
+prettyTypes :: Test
+prettyTypes = testGroup "printing types"
+  [ testFlatten "i32" (printType i32)
+  , testFlatten "f64" (printType f64)
+  , testFlatten "usize" (printType usize)
+  , testFlatten "[i32]" (printType (Slice i32 ()))
+  , testFlatten "[i32; 16]" (printType (Array i32 (Lit [] (Int 16 Unsuffixed ()) ()) ()))
+  , testFlatten "*const i32" (printType (Ptr Immutable i32 ()))
+  , testFlatten "*mut i32" (printType (Ptr Mutable i32 ()))
+  , testFlatten "&mut i32" (printType (Rptr Nothing Mutable i32 ()))
+  , testFlatten "&i32" (printType (Rptr Nothing Immutable i32 ()))
+  , testFlatten "&'lt mut i32" (printType (Rptr (Just (Lifetime (Name "lt") ())) Mutable i32 ()))
+  , testFlatten "&'lt i32" (printType (Rptr (Just (Lifetime (Name "lt") ())) Immutable i32 ()))
+  , testFlatten "!" (printType (Never ()))
+  , testFlatten "()" (printType (TupTy [] ()))
+  , testFlatten "(i32,)" (printType (TupTy [i32] ()))
+  , testFlatten "(i32, f64, usize)" (printType (TupTy [i32,f64,usize] ()))
+  , testFlatten "std::vec::Vec<i32>" (printType (PathTy Nothing (Path False [ std, vec, veci32 ] ()) ()))
+  , testFlatten "<i32 as std::vec>::Vec<i32>" (printType (PathTy (Just (QSelf i32 2)) (Path False [ std, vec, veci32 ] ()) ()))
+  , testFlatten "i32 + Debug + 'lt" (printType (ObjectSum i32 [ debug', lt ] ()))
+  , testFlatten "Debug + 'lt" (printType (PolyTraitRefTy [ debug', lt ] ()))
+  , testFlatten "impl Iterator<Item = i32> + 'lt" (printType (ImplTrait [ iterator, lt ] ()))
+  , testFlatten "(i32)" (printType (ParenTy i32 ()))
+  , testFlatten "typeof(1i32)" (printType (Typeof (Lit [] (Int 1 I32 ()) ()) ()))
+  , testFlatten "_" (printType (Infer ()))
+  , testFlatten "Self" (printType (ImplicitSelf ()))
+  , testFlatten "HList![&str, bool, Vec<i32>]"
+                (printType (MacTy (Mac (Path False [("HList", AngleBracketed [] [] [] ())] ())
+                                       [ Delimited mempty NoDelim mempty [ Token mempty Ampersand, Token mempty (IdentTok (mkIdent "str")) ] mempty 
+                                       , Token mempty (IdentTok (mkIdent "bool"))
+                                       , Delimited mempty NoDelim mempty [ Token mempty (IdentTok (mkIdent "Vec"))
+                                                                         , Token mempty Less
+                                                                         , Token mempty (IdentTok (mkIdent "i32"))
+                                                                         , Token mempty Greater
+                                                                         ] mempty
+                                       ]
+                                       ())
+                           ()))
+  , testFlatten "fn(i32) -> i32"
+                (printType (BareFn Normal Rust [] (FnDecl [Arg i32 (IdentP (ByValue Immutable) (mkIdent "") Nothing ()) ()] (Just i32) False ()) ()))
+  , testFlatten "unsafe extern \"C\" fn(i32) -> i32"
+                (printType (BareFn Unsafe C [] (FnDecl [Arg i32 (IdentP (ByValue Immutable) (mkIdent "") Nothing ()) ()] (Just i32) False ()) ()))
+  ]
+  where
+    -- Just a common type to make the tests above more straightforward
+    i32, f64, usize :: Ty ()
+    i32 = PathTy Nothing (Path False [("i32", AngleBracketed [] [] [] ())] ()) ()
+    f64 = PathTy Nothing (Path False [("f64", AngleBracketed [] [] [] ())] ()) ()
+    usize = PathTy Nothing (Path False [("usize", AngleBracketed [] [] [] ())] ()) ()
 
-Str String StrStyle Suffix a            -- ^ A string ("foo")
-  | ByteStr ByteString StrStyle Suffix a    -- ^ A byte string (b"foo")
-  | Char Char Suffix a                      -- ^ A character ('a')
-  | Byte Word8 Suffix a                     -- ^ A byte (b'f')
-  | Int Integer Suffix a                    -- ^ An integer (1)
-  | Float Double Suffix a                   -- ^ A float literal (1.12e4)
-  | Bool Bool Suffix a             
-  -}
+    -- Couple path segments
+    std = ("std", AngleBracketed [] [] [] ())
+    vec = ("vec", AngleBracketed [] [] [] ())
+    veci32 = ("Vec", AngleBracketed [] [i32] [] ())
+    debug = ("Debug", AngleBracketed [] [] [] ())
+
+    -- ty paramater bounds
+    debug' = TraitTyParamBound (PolyTraitRef [] (TraitRef (Path False [debug] ()) ()) ()) None
+    lt = RegionTyParamBound (Lifetime (Name "lt") ())
+    iterator = TraitTyParamBound (PolyTraitRef [] (TraitRef (Path False [("Iterator", AngleBracketed [] [] [(mkIdent "Item",i32)] ())] ()) ()) ()) None
+
+testRender :: String -> Doc a -> Test
+testRender str doc = testCase str $ str @=? display (renderPrettyDefault doc)
+
+testFlatten :: String -> Doc a -> Test
+testFlatten str doc = testCase str $ str @=? display (renderPrettyDefault (flatten doc))
+
+

--- a/tests/PrettyTest.hs
+++ b/tests/PrettyTest.hs
@@ -11,7 +11,7 @@ import Language.Rust.Pretty
 
 import Control.Monad
 import Control.Monad.Trans.Except
-import Text.PrettyPrint (render, Doc)
+import Text.PrettyPrint.Annotated.WL (Doc)
 
 prettySuite :: Test
 prettySuite = testGroup "pretty suite" [ commonCode, literals ]
@@ -31,8 +31,8 @@ literals = testGroup "printing literals"
   , testRender "false" (printLit (Bool False Unsuffixed ()))
   ]
 
-testRender :: String -> Doc -> Test
-testRender str doc = testCase str $ str @=? render doc
+testRender :: String -> Doc a -> Test
+testRender str doc = testCase str $ str @=? show doc
 {-
 data Suffix = Unsuffixed | Is | I8 | I16 | I32 | I64 | Us | U8 | U16 |  U32 | U64
 


### PR DESCRIPTION
This PR will fix #2. The `pretty` dependency is replaced with [`wl-pprint-annotated`][0].

[0]: https://hackage.haskell.org/package/wl-pprint-annotated