### PR TITLE
Add support for unquotation.

### DIFF
--- a/language-rust.cabal
+++ b/language-rust.cabal
@@ -89,6 +89,7 @@ library
                      , transformers         >=0.4  && <0.6
                      , array                >=0.5  && <0.6
                      , deepseq              >=1.1  && <1.5
+                     , syb                  >=0.5  && <0.8
 
   if flag(useByteStrings)
     cpp-options:       -DUSE_BYTESTRING
@@ -107,6 +108,7 @@ test-suite unit-tests
                        ParserTest
                        PrettyTest
                        CompleteTest
+                       QuoteTest
 
   other-extensions:    FlexibleContexts
                      , OverloadedStrings

--- a/src/Language/Rust/Data/Ident.hs
+++ b/src/Language/Rust/Data/Ident.hs
@@ -13,7 +13,7 @@ Data structure behind identifiers.
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveAnyClass #-}
 
-module Language.Rust.Data.Ident (Ident(..), mkIdent, Name) where
+module Language.Rust.Data.Ident (Ident(..), mkIdent, mkUnIdent, Name) where
 
 import GHC.Generics       ( Generic )
 
@@ -30,6 +30,7 @@ import Data.Semigroup as Sem
 data Ident
   = Ident { name :: Name                 -- ^ payload of the identifier
           , raw :: Bool                  -- ^ whether the identifier is raw
+          , unquote :: Bool              -- ^ whether the identifer should be unquoted
           , hash :: {-# UNPACK #-} !Int  -- ^ hash for quick comparision
           } deriving (Data, Typeable, Generic, NFData)
 
@@ -56,14 +57,17 @@ instance Monoid Ident where
   mappend = (<>)
   mempty = mkIdent ""
 
--- | "Forgets" about whether either argument was raw
+-- | "Forgets" about whether either argument was raw or unquoted
 instance Sem.Semigroup Ident where
-  Ident n1 _ _ <> Ident n2 _  _ = mkIdent (n1 <> n2)
-
+  Ident n1 _ _ _ <> Ident n2 _ _ _ = mkIdent (n1 <> n2)
 
 -- | Smart constructor for making an 'Ident'.
 mkIdent :: String -> Ident
-mkIdent s = Ident s False (hashString s)
+mkIdent s = Ident s False False (hashString s)
+
+-- | Smart constructor for making an 'Ident' for unquoting.
+mkUnIdent :: String -> Ident
+mkUnIdent s = Ident s False True (hashString s)
 
 -- | Hash a string into an 'Int'
 hashString :: String -> Int

--- a/src/Language/Rust/Parser/Internal.y
+++ b/src/Language/Rust/Parser/Internal.y
@@ -1410,6 +1410,8 @@ mod_item :: { Item Span }
     { macroItem $1 (Just (unspan $4)) (Mac $2 $6 ($2 # $>)) ($1 # $2 # $>) }
   | many(outer_attribute) expr_path '!'       '{' token_stream '}'
     { macroItem $1 Nothing            (Mac $2 $5 ($2 # $>)) ($1 # $2 # $>) }
+  | UNQUOTE_SPLICE
+    { let UnquoteSplTok  s = unspan $1 in UnquoteItems [] s (spanOf $1) }
 
 foreign_item :: { ForeignItem Span }
   : many(outer_attribute) vis static     ident ':' ty ';'

--- a/src/Language/Rust/Parser/Internal.y
+++ b/src/Language/Rust/Parser/Internal.y
@@ -926,7 +926,7 @@ gen_expression(lhs,rhs,rhs2) :: { Expr Span }
   -- immediate expressions
   : ntExpr                           { $1 }
   | lit_expr                         { $1 }
-  | UNQUOTE_EXPR                     { let UnquoteExprTok s = unspan $1 in UnquoteExpr s (spanOf $1) }
+  | UNQUOTE_EXPR                     { let UnquoteExprTok s = unspan $1 in UnquoteExpr [] s (spanOf $1) }
   | '[' sep_byT(expr,',') ']'        { Vec [] $2 ($1 # $>) }
   | '[' inner_attrs sep_byT(expr,',') ']' { Vec (toList $2) $3 ($1 # $>) }
   | '[' expr ';' expr ']'            { Repeat [] $2 $4 ($1 # $>) }
@@ -1907,6 +1907,7 @@ addAttrs as (Repeat as' e1 e2 s)     = Repeat (as ++ as') e1 e2 s
 addAttrs as (ParenExpr as' e s)      = ParenExpr (as ++ as') e s
 addAttrs as (Try as' e s)            = Try (as ++ as') e s
 addAttrs as (Yield as' e s)          = Yield (as ++ as') e s
+addAttrs as (UnquoteExpr as' a s)    = UnquoteExpr (as ++ as') a s
 
 
 -- | Given a 'LitTok' token that is expected to result in a valid literal, construct the associated

--- a/src/Language/Rust/Pretty/Internal.hs
+++ b/src/Language/Rust/Pretty/Internal.hs
@@ -413,7 +413,7 @@ printExprOuterAttrStyle expr isInline = glue (printEitherAttrs (expressionAttrs 
     Repeat attrs e cnt x        -> annotate x (brackets (printInnerAttrs attrs <+> printExpr e <> ";" <+> printExpr cnt))
     ParenExpr attrs e x         -> annotate x (parens (printInnerAttrs attrs <+> printExpr e))
     Try{}                       -> chainedMethodCalls expr False id
-    UnquoteExpr s _             -> error ("Lingering unquote expression '" ++ s ++ "'")
+    UnquoteExpr _ s _           -> error ("Lingering unquote expression '" ++ s ++ "'")
   where
   printLbl = perhaps (\(Label n x) -> annotate x ("'" <> printName n) <> ":")
   printLbl' = perhaps (\(Label n x) -> annotate x ("'" <> printName n))
@@ -496,7 +496,7 @@ expressionAttrs (Repeat as _ _ _) = as
 expressionAttrs (ParenExpr as _ _) = as
 expressionAttrs (Try as _ _) = as
 expressionAttrs (Yield as _ _) = as
-expressionAttrs (UnquoteExpr _ _) = []
+expressionAttrs (UnquoteExpr as _ _) = as
 
 -- | Print a field
 printField :: Field a -> Doc a

--- a/src/Language/Rust/Pretty/Internal.hs
+++ b/src/Language/Rust/Pretty/Internal.hs
@@ -684,6 +684,8 @@ printItem (MacItem as i (Mac p ts y) x) = annotate x $ annotate y $ align $ prin
 printItem (MacroDef as i ts x) = annotate x $ align $ printOuterAttrs as <#>
   ("macro_rules" <> "!" <+> printIdent i <+> block Brace True mempty mempty [ printTokenStream ts ])
 
+printItem (UnquoteItems _ _ _) =
+  error ("print_item ran into a lingering UnquoteItems")
 
 -- | Print a trait item (@print_trait_item@)
 printTraitItem :: TraitItem a -> Doc a

--- a/src/Language/Rust/Pretty/Internal.hs
+++ b/src/Language/Rust/Pretty/Internal.hs
@@ -124,8 +124,9 @@ printName = pretty
 
 -- | Print an identifier
 printIdent :: Ident -> Doc a
-printIdent (Ident s False _) = pretty s
-printIdent (Ident s True _) = "r#" <> pretty s
+printIdent (Ident s _     True  _) = error ("Lingering unquote identifer '" ++ s ++ "'")
+printIdent (Ident s False False _) = pretty s
+printIdent (Ident s True  False _) = "r#" <> pretty s
 
 -- | Print a type (@print_type@ with @print_ty_fn@ inlined)
 -- Types are expected to always be only one line
@@ -290,6 +291,9 @@ printToken Shebang = "#!"
 -- Macro related 
 printToken (Interpolated n) = unAnnotate (printNonterminal n)
 -- Other
+printToken (UnquoteExprTok s) = "$$(" <> printName s <> ")"
+printToken (UnquoteStmtTok s) = "$${" <> printName s <> "}"
+printToken (UnquoteSplTok s) = "$@{" <> printName s <> "}"
 printToken t = error $ "printToken: " ++ show t
 
 
@@ -327,6 +331,8 @@ printNonterminal (NtLit lit) = printLit lit
 -- | Print a statement (@print_stmt@)
 printStmt :: Stmt a -> Doc a
 printStmt (ItemStmt item x)   = annotate x (printItem item)
+printStmt (UnquoteStmt s _)   = error ("Ran into lingering unquote statement '" ++ s ++ "'")
+printStmt (UnquoteSplice s _) = error ("Ran into lingering unquote splice '" ++ s ++ "'")
 printStmt (NoSemi expr x)     = annotate x (printExprOuterAttrStyle expr False <> when (requiresSemi expr) ";")
   where
   -- @parse::classify::expr_requires_semi_to_be_stmt@
@@ -407,6 +413,7 @@ printExprOuterAttrStyle expr isInline = glue (printEitherAttrs (expressionAttrs 
     Repeat attrs e cnt x        -> annotate x (brackets (printInnerAttrs attrs <+> printExpr e <> ";" <+> printExpr cnt))
     ParenExpr attrs e x         -> annotate x (parens (printInnerAttrs attrs <+> printExpr e))
     Try{}                       -> chainedMethodCalls expr False id
+    UnquoteExpr s _             -> error ("Lingering unquote expression '" ++ s ++ "'")
   where
   printLbl = perhaps (\(Label n x) -> annotate x ("'" <> printName n) <> ":")
   printLbl' = perhaps (\(Label n x) -> annotate x ("'" <> printName n))
@@ -489,6 +496,7 @@ expressionAttrs (Repeat as _ _ _) = as
 expressionAttrs (ParenExpr as _ _) = as
 expressionAttrs (Try as _ _) = as
 expressionAttrs (Yield as _ _) = as
+expressionAttrs (UnquoteExpr _ _) = []
 
 -- | Print a field
 printField :: Field a -> Doc a
@@ -599,7 +607,8 @@ printAttr (SugaredDoc Outer False c x) _ = annotate x (flatAlt ("///" <> pretty 
 
 -- | Print an identifier as is, or as cooked string if containing a hyphen
 printCookedIdent :: Ident -> Doc a
-printCookedIdent ident@(Ident str raw _)
+printCookedIdent ident@(Ident str raw unquote _)
+  | unquote = error ("Lingering unquote ident '" ++ str ++ "' (2)")
   | '-' `elem` str && not raw = printStr Cooked str
   | otherwise = printIdent ident 
 

--- a/src/Language/Rust/Pretty/Resolve.hs
+++ b/src/Language/Rust/Pretty/Resolve.hs
@@ -1040,7 +1040,7 @@ resolveExprP _ _ c@(Catch as b x) = scope c $ do
   as' <- traverse (resolveAttr EitherAttr) as
   b' <- resolveBlock b
   pure (Catch as' b' x)
-resolveExprP _ _ x@(UnquoteExpr _ _) =
+resolveExprP _ _ x@(UnquoteExpr _ _ _) =
   pure x
 
 isBlockLike :: Expr a -> Bool

--- a/src/Language/Rust/Pretty/Resolve.hs
+++ b/src/Language/Rust/Pretty/Resolve.hs
@@ -1280,6 +1280,9 @@ resolveItem _ m@(MacroDef as i ts x) = scope m $ do
   ts' <- resolveTokenStream ts
   pure (MacroDef as' i' ts' x)
 
+resolveItem _ m@(UnquoteItems _ _ _) =
+  pure m
+
 instance (Typeable a, Monoid a) => Resolve (Item a) where resolveM = resolveItem ModItem
 
 -- | A foreign item is invalid only if any of its underlying constituents are 

--- a/src/Language/Rust/Pretty/Resolve.hs
+++ b/src/Language/Rust/Pretty/Resolve.hs
@@ -231,7 +231,9 @@ instance (Typeable a, Monoid a) => Resolve (SourceFile a) where resolveM = resol
 --   * it is a keyword
 --
 resolveIdent :: Ident -> ResolveM Ident
-resolveIdent i@(Ident s r _) =
+resolveIdent i@(Ident _ _ True  _) =
+    return i
+resolveIdent i@(Ident s r False _) =
     scope i $ case toks of
                 Right [Spanned (IdentTok i') _]
                    | i /= i' -> err i ("identifier `" ++ s ++ "' does not lex properly")
@@ -359,10 +361,10 @@ resolvePath t p@(Path g segs x) = scope p $
   resolveSeg :: (Typeable a, Monoid a) => PathSegment a -> ResolveM (PathSegment a)
   resolveSeg (PathSegment i a x') = do
     i' <- case i of
-            Ident "self" False _ -> pure i
-            Ident "Self" False _ -> pure i
-            Ident "super" False _ -> pure i
-            Ident "crate" False _ -> pure i
+            Ident "self"  False False _ -> pure i
+            Ident "Self"  False False _ -> pure i
+            Ident "super" False False _ -> pure i
+            Ident "crate" False False _ -> pure i
             _ -> resolveIdent i
     a' <- traverse resolvePathParameters a
     pure (PathSegment i' a' x')
@@ -544,8 +546,8 @@ resolveArg GeneralArg a@(Arg p t x) = scope a $ do
 
 -- | Check whether an argument is one of the "self"-alike forms
 isSelfAlike :: Arg a -> Bool
-isSelfAlike (Arg Nothing (PathTy Nothing (Path False [PathSegment (Ident "self" False _) Nothing _] _) _) _) = True
-isSelfAlike (Arg Nothing (Rptr _ _ (PathTy Nothing (Path False [PathSegment (Ident "self" False _) Nothing _] _) _) _) _) = True
+isSelfAlike (Arg Nothing (PathTy Nothing (Path False [PathSegment (Ident "self" False _ _) Nothing _] _) _) _) = True
+isSelfAlike (Arg Nothing (Rptr _ _ (PathTy Nothing (Path False [PathSegment (Ident "self" False _ _) Nothing _] _) _) _) _) = True
 isSelfAlike _ = False
 
 instance (Typeable a, Monoid a) => Resolve (Arg a) where resolveM = resolveArg NamedArg
@@ -1037,7 +1039,9 @@ resolveExprP _ _ m@(Match as e ar x) = scope m $ do
 resolveExprP _ _ c@(Catch as b x) = scope c $ do
   as' <- traverse (resolveAttr EitherAttr) as
   b' <- resolveBlock b
-  pure (Catch as' b' x) 
+  pure (Catch as' b' x)
+resolveExprP _ _ x@(UnquoteExpr _ _) =
+  pure x
 
 isBlockLike :: Expr a -> Bool
 isBlockLike If{} = True
@@ -1106,6 +1110,10 @@ resolveStmt _ a@(MacStmt m s as x) = scope a $ do
   m' <- resolveMac ExprPath m
   as' <- traverse (resolveAttr OuterAttr) as
   pure (MacStmt m' s as' x)
+resolveStmt _ a@(UnquoteStmt _ _) =
+  pure a
+resolveStmt _ a@(UnquoteSplice _ _) =
+  pure a
 
 instance (Typeable a, Monoid a) => Resolve (Stmt a) where resolveM = resolveStmt AnyStmt
 

--- a/src/Language/Rust/Quote.hs
+++ b/src/Language/Rust/Quote.hs
@@ -24,6 +24,9 @@ The examples below assume the following GHCi flag and import:
 This quotation library allows a restricted amount of unquoting, which allow you to splice
 computed ASTs into a quoted item. In particular, you can:
 
+  * Splice in an identifier (in any number of helpful places, including function names,
+    use statements, etc.) by using @$$foo@ where @foo@ is a Haskell identifier in scope
+    that has type `Language.Rust.Data.Ident`.
   * Splice in an expression by using @$$(foo)@, where @foo@ is a Haskell identifier in
     scope that has the type `Language.Rust.Syntax.Expr`.
   * Splice in a single statement by using @$${foo}@, where @foo@ is a Haskell identifer

--- a/src/Language/Rust/Quote.hs
+++ b/src/Language/Rust/Quote.hs
@@ -147,7 +147,7 @@ qqExp = const Nothing `extQ` replaceExpressions
 
 -- | Replace unquotes within expressions with TH references to the given name.
 replaceExpressions :: Expr Span -> Maybe (Q Exp)
-replaceExpressions (UnquoteExpr n _) = Just (varE (mkName n))
+replaceExpressions (UnquoteExpr _ n _) = Just (varE (mkName n))
 replaceExpressions _ = Nothing
 
 -- | Replace unquotes within statements with TH references to the given name.

--- a/src/Language/Rust/Syntax/AST.hs
+++ b/src/Language/Rust/Syntax/AST.hs
@@ -370,7 +370,7 @@ data Expr a
   -- | @yield@ with an optional value to yield (example: @yield 1@)
   | Yield [Attribute a] (Maybe (Expr a)) a
   -- | A quasiquote unquote; the string should be a Haskell identifier to reference
-  | UnquoteExpr String a
+  | UnquoteExpr [Attribute a] String a
   deriving (Eq, Ord, Functor, Show, Typeable, Data, Generic, Generic1, NFData)
 
 instance Located a => Located (Expr a) where
@@ -412,7 +412,7 @@ instance Located a => Located (Expr a) where
   spanOf (ParenExpr _ _ s) = spanOf s
   spanOf (Try _ _ s) = spanOf s
   spanOf (Yield _ _ s) = spanOf s
-  spanOf (UnquoteExpr _ s) = spanOf s
+  spanOf (UnquoteExpr _ _ s) = spanOf s
 
 -- | Field in a struct literal expression (@syntax::ast::Field@).
 --

--- a/src/Language/Rust/Syntax/AST.hs
+++ b/src/Language/Rust/Syntax/AST.hs
@@ -601,6 +601,9 @@ data Item a
   -- | definition of a macro via @macro_rules@
   -- Example: @macro_rules! foo { .. }@
   | MacroDef [Attribute a] Ident TokenStream a
+  -- | an unquote splice, in which we should throw in a bunch of to-be-generated
+  -- items
+  | UnquoteItems [Attribute a] String a
   deriving (Eq, Ord, Functor, Show, Typeable, Data, Generic, Generic1, NFData)
 
 instance Located a => Located (Item a) where
@@ -620,6 +623,7 @@ instance Located a => Located (Item a) where
   spanOf (Impl _ _ _ _ _ _ _ _ _ s) = spanOf s
   spanOf (MacItem _ _ _ s) = spanOf s
   spanOf (MacroDef _ _ _ s) = spanOf s
+  spanOf (UnquoteItems _ _ s) = spanOf s
 
 -- | Used to annotate loops, breaks, continues, etc.
 data Label a = Label Name a

--- a/src/Language/Rust/Syntax/AST.hs
+++ b/src/Language/Rust/Syntax/AST.hs
@@ -369,6 +369,8 @@ data Expr a
   | Try [Attribute a] (Expr a) a
   -- | @yield@ with an optional value to yield (example: @yield 1@)
   | Yield [Attribute a] (Maybe (Expr a)) a
+  -- | A quasiquote unquote; the string should be a Haskell identifier to reference
+  | UnquoteExpr String a
   deriving (Eq, Ord, Functor, Show, Typeable, Data, Generic, Generic1, NFData)
 
 instance Located a => Located (Expr a) where
@@ -410,6 +412,7 @@ instance Located a => Located (Expr a) where
   spanOf (ParenExpr _ _ s) = spanOf s
   spanOf (Try _ _ s) = spanOf s
   spanOf (Yield _ _ s) = spanOf s
+  spanOf (UnquoteExpr _ s) = spanOf s
 
 -- | Field in a struct literal expression (@syntax::ast::Field@).
 --
@@ -877,6 +880,10 @@ data Stmt a
   | Semi (Expr a) a
   -- | A macro call (example: @println!("hello world")@)
   | MacStmt (Mac a) MacStmtStyle [Attribute a] a
+  -- | A template Rust statement that should be expanded
+  | UnquoteStmt String a
+  -- } A series of template Rust statements that should be spliced into a block
+  | UnquoteSplice String a
   deriving (Eq, Ord, Functor, Show, Typeable, Data, Generic, Generic1, NFData)
 
 instance Located a => Located (Stmt a) where
@@ -885,6 +892,8 @@ instance Located a => Located (Stmt a) where
   spanOf (NoSemi _ s) = spanOf s
   spanOf (Semi _ s) = spanOf s
   spanOf (MacStmt _ _ _ s) = spanOf s
+  spanOf (UnquoteStmt _ s) = spanOf s
+  spanOf (UnquoteSplice _ s) = spanOf s
 
 -- | Style of a string literal (@syntax::ast::StrStyle@).
 data StrStyle
@@ -1195,4 +1204,3 @@ instance Located a => Located (WherePredicate a) where
   spanOf (BoundPredicate _ _ _ s) = spanOf s
   spanOf (RegionPredicate _ _ s) = spanOf s
   spanOf (EqPredicate _ _ s) = spanOf s
-

--- a/src/Language/Rust/Syntax/Token.hs
+++ b/src/Language/Rust/Syntax/Token.hs
@@ -105,6 +105,9 @@ data Token
   -- ^ doc comment with its contents, whether it is outer/inner, and whether it is inline or not
   | Shebang               -- ^ @#!@ shebang token
   | Eof                   -- ^ end of file token
+  | UnquoteExprTok String -- ^ An unquote for Haskell quasiquoting of expression
+  | UnquoteStmtTok String -- ^ An unquote for Haskell quasiquoting of statement
+  | UnquoteSplTok  String -- ^ An unquote for a sequence of statements
   
   -- NOT PRODUCED IN TOKENIZATION!!
   | Interpolated (Nonterminal Span) -- ^ can be expanded into several tokens in macro-expansion
@@ -355,6 +358,9 @@ instance Show Token where
   show (LiteralTok (ByteStrRawTok n i) s) = "br" ++ replicate i '#' ++ "\"" ++ n ++ "\"" ++ replicate i '#' ++ fromMaybe "" s
   -- Name components
   show (IdentTok i) = name i
+  show (UnquoteExprTok s) = "$$(" ++ s ++ ")"
+  show (UnquoteStmtTok s) = "$${" ++ s ++ "}"
+  show (UnquoteSplTok s) = "$@{" ++ s ++ "}"
   show (LifetimeTok l) = "'" ++ show l
   show (Space Whitespace _) = "<whitespace>"
   show (Space Comment n) = "/*" ++ show n ++ " */"

--- a/test/rustc-tests/Diff.hs
+++ b/test/rustc-tests/Diff.hs
@@ -636,8 +636,8 @@ instance Show a => Diffable (Field a) where
       me === (val ! "expr")
 
 instance Diffable Ident where
-  Ident i _ _ === String s | fromString i == s = pure ()
-  ident'      === val = diff "identifiers are different" ident' val
+  Ident i _ _ _ === String s | fromString i == s = pure ()
+  ident'        === val = diff "identifiers are different" ident' val
 
 -- | The empty identifier is invalid
 invalidIdent :: Ident

--- a/test/unit-tests/Main.hs
+++ b/test/unit-tests/Main.hs
@@ -6,8 +6,9 @@ import LexerTest (lexerSuite)
 import ParserTest (parserSuite)
 import PrettyTest (prettySuite)
 import CompleteTest (completeSuite)
+import QuoteTest (quoteSuite)
 
 import Test.Framework (defaultMain)
 
 main :: IO ()
-main = hSetEncoding stdout utf8 *> defaultMain [ lexerSuite, parserSuite, prettySuite, completeSuite ]
+main = hSetEncoding stdout utf8 *> defaultMain [ lexerSuite, parserSuite, prettySuite, completeSuite, quoteSuite ]

--- a/test/unit-tests/QuoteTest.hs
+++ b/test/unit-tests/QuoteTest.hs
@@ -1,0 +1,94 @@
+{-# LANGUAGE QuasiQuotes #-}
+module QuoteTest(quoteSuite) where
+
+import Language.Rust.Data.Ident(mkIdent)
+import Language.Rust.Quote
+import Language.Rust.Pretty(Pretty,Resolve,pretty')
+import Prelude hiding (lines)
+import Test.Framework(Test,testGroup)
+import Test.Framework.Providers.HUnit
+import Test.HUnit hiding (Test)
+
+-- | The goal of these is to make sure quoting an unquoting work the way they're
+-- supposed to. It will be delicate in the face of changing renderers,
+-- unfortunately.
+quoteSuite :: Test
+quoteSuite = testGroup "quote suite"
+  [ quoteTest "Standard Quote (lit)"
+              "23"
+              [lit| 23 |]
+  --
+  , quoteTest "Standard Quote (1+1)"
+              "1 + 1"
+              [expr| 1 + 1 |]
+  --
+  , quoteTest "Unquote literal (1+1)"
+              "1 + 1"
+              [expr| $$(one) + 1 |]
+  --
+  , quoteTest "Unquote if test"
+              "if 2 > 1 { return true; }"
+              [stmt| if $$(tg1) { return true; } |]
+  --
+  , quoteTest "Unquote if consequent"
+              "if 2 > 1 { return true; }"
+              [stmt| if 2 > 1 { $${ret1} } |]
+  --
+  , quoteTest "Unquote data type"
+              "struct Foo {\n  inner: u64,\n}"
+              [item| struct $$name { inner: u64 } |]
+  --
+  , quoteTest "Unquote field type"
+              "struct Foo {\n  inner: u64,\n}"
+              [item| struct $$name { $$field: u64 } |]
+  --
+  , quoteTest "Unquote field array type"
+              "struct Foo {\n  inner: [u64; 1],\n}"
+              [item| struct $$name { $$field: [u64; $$(one)] } |]
+  --
+  , quoteTest "Impl trait name"
+              "impl Add<Output = Foo> for Foo {\n  fn foo(&self, other: Foo) -> Self {\n    unimplemented!()\n  }\n}"
+              [item| impl Add<Output=$$name> for $$name {
+                        fn foo(&self, other: $$name) -> Self {
+                            unimplemented!()
+                        }
+                     }|]
+  --
+  , quoteTest "In macro argument literal"
+              "write!(f,                           \"{:X}\", 1)?;"
+              [stmt| write!(f, $$(hashx), 1)?; |]
+  , quoteTest "Statement splice"
+              "fn foo(x: u64) -> u64 {\n  let mut v = x;\n  v = v / 2;\n  v = v + 1;\n  v\n}"
+              [item|
+               fn foo(x: u64) -> u64 {
+                    let mut v = x;
+                    $@{lines};
+                    v
+               }
+              |]
+  , quoteTest "Documentation example"
+              "fn foo(x: u64) -> u64 {\n  let mut v = 1;\n  v = v + 1;\n  v = v + 1;\n  v = v + 1;\n  v = v + 1;\n  v = v + 1;\n  v = v + 1;\n  v = v + 1;\n  v = v + 1;\n  v = v + 1;\n  v = v + 1;\n  v = v % 10;\n  return v;\n}"
+              (let initial_value = [expr| 1 |]
+                   return_value  = [stmt| return v; |]
+                   plusOnes      = replicate 10 [stmt| v = v + 1; |]
+               in [item|
+                     fn foo(x: u64) -> u64 {
+                       let mut v = $$(initial_value);
+                       $@{plusOnes}
+                       v = v % 10;
+                       $${return_value}
+                      }
+                  |])
+  ]
+ where
+  one = [expr| 1 |]
+  tg1 = [expr| 2 > 1 |]
+  hashx = [tokenTree| "{:X}" |]
+  ret1 = [stmt| return true; |]
+  name = mkIdent "Foo"
+  field = mkIdent "inner"
+  lines = [ [stmt| v = v / 2; |],
+            [stmt| v = v + 1; |] ]
+
+quoteTest :: (Pretty a, Resolve a) => String -> String -> a -> Test
+quoteTest name res v = testCase name (res @=? show (pretty' v))


### PR DESCRIPTION
This set of patches adds in the ability to do unquotation in a variety of places:

  * As identifiers: ```[item| fn $$foo(x: u8) -> u8 { return 0; } |]```
  * As expressions: ```[expr| 1 + $$(one) |]```
  * As statements: ```[stmt| if x > 3 { $${something} } |]
  * As a series of statements: ```[stmt| if x > 3 { $@{somethings} } |]```

... and so on. The syntax was not a particularly well-thought-out choice, and should be pretty easy to change if you don't like it. Right now, this only supports identifiers as the splice (e.g., ```$$(foo)``` but not ```$$(foo 4)```); it wasn't super clear how to do this easily.