### PR TITLE
Fix the `Ord` instance for `Ident` + some other small fixes

### DIFF
--- a/src/Language/Rust/Data/Ident.hs
+++ b/src/Language/Rust/Data/Ident.hs
@@ -33,7 +33,13 @@ data Ident
   = Ident { hash :: {-# UNPACK #-} !Int  -- ^ hash for quick comparision
           , name :: Name                 -- ^ payload of the identifier
           , raw :: Bool                  -- ^ whether the identifier is raw
-          } deriving (Data, Typeable, Generic, NFData, Eq, Ord)
+          } deriving (Data, Typeable, Generic, NFData)
+
+instance Eq Ident where
+  x == y = (hash x, name x) == (hash y, name y)
+
+instance Ord Ident where
+  compare x y = compare (hash x, name x) (hash y, name y)
 
 -- | Shows the identifier as a string (for use with @-XOverloadedStrings@)
 instance Show Ident where

--- a/src/Language/Rust/Parser/Internal.y
+++ b/src/Language/Rust/Parser/Internal.y
@@ -585,7 +585,7 @@ self_or_ident :: { Spanned Ident }
 -----------
 
 lifetime :: { Lifetime Span }
-  : LIFETIME                         { let Spanned (LifetimeTok (Ident l _ _)) s = $1 in Lifetime l s }
+  : LIFETIME                         { let Spanned (LifetimeTok l) s = $1 in Lifetime (name l) s }
 
 -- parse_trait_ref()
 trait_ref :: { TraitRef Span }
@@ -1125,7 +1125,7 @@ blockpostfix_expr :: { Expr Span }
 
 -- labels on loops
 label :: { Label Span }
-  : LIFETIME                         { let Spanned (LifetimeTok (Ident l _ _)) s = $1 in Label l s }
+  : LIFETIME                         { let Spanned (LifetimeTok l) s = $1 in Label (name l) s }
 
 -- Literal expressions (composed of just literals)
 lit_expr :: { Expr Span }
@@ -1904,8 +1904,8 @@ addAttrs as (Yield as' e s)          = Yield (as ++ as') e s
 -- | Given a 'LitTok' token that is expected to result in a valid literal, construct the associated
 -- literal. Note that this should _never_ fail on a token produced by the lexer.
 lit :: Spanned Token -> Lit Span
-lit (Spanned (IdentTok (Ident "true" False _)) s) = Bool True Unsuffixed s
-lit (Spanned (IdentTok (Ident "false" False _)) s) = Bool False Unsuffixed s
+lit (Spanned (IdentTok Ident { name = "true", raw = False }) s) = Bool True Unsuffixed s
+lit (Spanned (IdentTok Ident { name = "false", raw = False }) s) = Bool False Unsuffixed s
 lit (Spanned (LiteralTok litTok suffix_m) s) = translateLit litTok suffix s
   where
     suffix = case suffix_m of

--- a/src/Language/Rust/Parser/Lexer.x
+++ b/src/Language/Rust/Parser/Lexer.x
@@ -1104,7 +1104,7 @@ literal lit = do
     AlexToken (pos',inp') len action -> do
         tok <- action (peekChars len inp)
         case tok of
-          IdentTok (Ident suf False _) -> do
+          IdentTok Ident { name = suf, raw = False } -> do
             setPosition pos'
             setInput inp'
             pure (LiteralTok lit (Just suf))

--- a/src/Language/Rust/Parser/Reversed.hs
+++ b/src/Language/Rust/Parser/Reversed.hs
@@ -51,7 +51,7 @@ instance Sem.Semigroup (f a) => Sem.Semigroup (Reversed f a) where
 
 instance Monoid (f a) => Monoid (Reversed f a) where
   mempty = Reversed mempty
-  mappend (Reversed xs) (Reversed ys) = Reversed (mappend ys xs)
+  mappend = (<>)
 
 instance G.IsList (f a) => G.IsList (Reversed f a) where
   type Item (Reversed f a) = G.Item (f a)

--- a/src/Language/Rust/Pretty.hs
+++ b/src/Language/Rust/Pretty.hs
@@ -77,9 +77,9 @@ import Language.Rust.Pretty.Resolve
 
 import System.IO                             ( Handle )
 import Data.Typeable                         ( Typeable )
-import Data.Text.Prettyprint.Doc.Render.Text ( renderIO )
-import Data.Text.Prettyprint.Doc             ( Doc )
-import qualified Data.Text.Prettyprint.Doc as PP
+import Prettyprinter.Render.Text ( renderIO )
+import Prettyprinter                         ( Doc )
+import qualified Prettyprinter as PP
 
 import Control.Exception                     ( throw )
 

--- a/src/Language/Rust/Pretty/Internal.hs
+++ b/src/Language/Rust/Pretty/Internal.hs
@@ -947,7 +947,12 @@ printGenerics (Generics lifetimes tyParams _ x)
   | null lifetimes && null tyParams = mempty
   | otherwise =  let lifetimes' = printLifetimeDef `map` lifetimes
                      bounds' = [ printTyParam param | param<-tyParams ]
-                 in annotate x (group ("<" <##> ungroup (block NoDelim True "," mempty (lifetimes' ++ bounds')) <##> ">"))
+                 in annotate x (group ("<" <##> vsep (go (lifetimes' ++ bounds')) <##> ">"))
+  where
+  go []     = []
+  go [z]    = [ flatAlt (indent n z <> ",") (flatten z) ]
+  go (z:zs) = flatAlt (indent n z <> ",") (flatten z <> ",") : go zs
+
 
 -- | Print a poly-trait ref (@print_poly_trait_ref@)
 printPolyTraitRef :: PolyTraitRef a -> Doc a

--- a/src/Language/Rust/Pretty/Internal.hs
+++ b/src/Language/Rust/Pretty/Internal.hs
@@ -124,8 +124,7 @@ printName = pretty
 
 -- | Print an identifier
 printIdent :: Ident -> Doc a
-printIdent (Ident s False _) = pretty s
-printIdent (Ident s True _) = "r#" <> pretty s
+printIdent n = if raw n then "r#" <> pretty (name n) else pretty (name n)
 
 -- | Print a type (@print_type@ with @print_ty_fn@ inlined)
 -- Types are expected to always be only one line
@@ -599,7 +598,7 @@ printAttr (SugaredDoc Outer False c x) _ = annotate x (flatAlt ("///" <> pretty 
 
 -- | Print an identifier as is, or as cooked string if containing a hyphen
 printCookedIdent :: Ident -> Doc a
-printCookedIdent ident@(Ident str raw _)
+printCookedIdent ident@(Ident { name = str, raw = raw })
   | '-' `elem` str && not raw = printStr Cooked str
   | otherwise = printIdent ident 
 

--- a/src/Language/Rust/Pretty/Literals.hs
+++ b/src/Language/Rust/Pretty/Literals.hs
@@ -19,7 +19,7 @@ module Language.Rust.Pretty.Literals (
 import Language.Rust.Syntax.AST
 import Language.Rust.Pretty.Util
 
-import Data.Text.Prettyprint.Doc ( hcat, annotate, (<>), Doc, pretty, group, hardline, flatAlt )
+import Prettyprinter ( hcat, annotate, Doc, pretty, group, hardline, flatAlt )
 
 import Data.Char                 ( intToDigit, ord, chr )
 import Data.Word                 ( Word8 )

--- a/src/Language/Rust/Pretty/Resolve.hs
+++ b/src/Language/Rust/Pretty/Resolve.hs
@@ -85,7 +85,6 @@ import Data.List                       ( find )
 import Data.List.NonEmpty              ( NonEmpty(..) )
 import qualified Data.List.NonEmpty as N
 import Data.Maybe                      ( fromJust )
-import Data.Semigroup                  ( (<>) )
 
 {-# ANN module "HLint: ignore Reduce duplication" #-}
 

--- a/src/Language/Rust/Pretty/Resolve.hs
+++ b/src/Language/Rust/Pretty/Resolve.hs
@@ -231,7 +231,7 @@ instance (Typeable a, Monoid a) => Resolve (SourceFile a) where resolveM = resol
 --   * it is a keyword
 --
 resolveIdent :: Ident -> ResolveM Ident
-resolveIdent i@(Ident s r _) =
+resolveIdent i@(Ident { name = s, raw = r }) =
     scope i $ case toks of
                 Right [Spanned (IdentTok i') _]
                    | i /= i' -> err i ("identifier `" ++ s ++ "' does not lex properly")
@@ -359,10 +359,10 @@ resolvePath t p@(Path g segs x) = scope p $
   resolveSeg :: (Typeable a, Monoid a) => PathSegment a -> ResolveM (PathSegment a)
   resolveSeg (PathSegment i a x') = do
     i' <- case i of
-            Ident "self" False _ -> pure i
-            Ident "Self" False _ -> pure i
-            Ident "super" False _ -> pure i
-            Ident "crate" False _ -> pure i
+            Ident { name = "self",  raw = False } -> pure i
+            Ident { name = "Self",  raw = False } -> pure i
+            Ident { name = "super", raw = False } -> pure i
+            Ident { name = "crate", raw = False } -> pure i
             _ -> resolveIdent i
     a' <- traverse resolvePathParameters a
     pure (PathSegment i' a' x')
@@ -544,8 +544,8 @@ resolveArg GeneralArg a@(Arg p t x) = scope a $ do
 
 -- | Check whether an argument is one of the "self"-alike forms
 isSelfAlike :: Arg a -> Bool
-isSelfAlike (Arg Nothing (PathTy Nothing (Path False [PathSegment (Ident "self" False _) Nothing _] _) _) _) = True
-isSelfAlike (Arg Nothing (Rptr _ _ (PathTy Nothing (Path False [PathSegment (Ident "self" False _) Nothing _] _) _) _) _) = True
+isSelfAlike (Arg Nothing (PathTy Nothing (Path False [PathSegment Ident { name = "self", raw = False } Nothing _] _) _) _) = True
+isSelfAlike (Arg Nothing (Rptr _ _ (PathTy Nothing (Path False [PathSegment Ident { name = "self", raw = False } Nothing _] _) _) _) _) = True
 isSelfAlike _ = False
 
 instance (Typeable a, Monoid a) => Resolve (Arg a) where resolveM = resolveArg NamedArg

--- a/src/Language/Rust/Pretty/Util.hs
+++ b/src/Language/Rust/Pretty/Util.hs
@@ -25,8 +25,8 @@ module Language.Rust.Pretty.Util where
 
 import Data.Monoid as M
 
-import qualified Data.Text.Prettyprint.Doc as PP
-import Data.Text.Prettyprint.Doc.Internal.Type ( Doc(..) )
+import qualified Prettyprinter as PP
+import Prettyprinter.Internal.Type ( Doc(..) )
 
 import Language.Rust.Syntax.Token ( Delim(..) )
 

--- a/test/rustc-tests/Diff.hs
+++ b/test/rustc-tests/Diff.hs
@@ -636,8 +636,8 @@ instance Show a => Diffable (Field a) where
       me === (val ! "expr")
 
 instance Diffable Ident where
-  Ident i _ _ === String s | fromString i == s = pure ()
-  ident'      === val = diff "identifiers are different" ident' val
+  i       === String s | fromString (name i) == s = pure ()
+  ident'  === val = diff "identifiers are different" ident' val
 
 -- | The empty identifier is invalid
 invalidIdent :: Ident

--- a/test/rustc-tests/DiffUtils.hs
+++ b/test/rustc-tests/DiffUtils.hs
@@ -5,7 +5,7 @@
 module DiffUtils where
 
 import qualified Data.Aeson as Aeson
-import qualified Data.HashMap.Lazy as HM
+import qualified Data.Aeson.KeyMap as Aeson
 import qualified Data.Vector as V
 import qualified Data.List.NonEmpty as N
 import Control.Monad
@@ -24,10 +24,16 @@ instance IsString AesonKey where fromString = Key
 
 -- | Accessor method for JSON with helpful error messages.
 (!) :: Aeson.Value -> AesonKey -> Aeson.Value
-val@(Aeson.Object hashmap) ! Key key =
-  case HM.lookup (fromString key) hashmap of
-    Nothing -> error $ "No key `" ++ key ++ "' on JSON object `" ++ showAeson val ++ "'"
+val@(Aeson.Object hashmap) ! key =
+  case Aeson.lookup (fromString keyString) hashmap of
+    Nothing -> error $ "No key `" ++ keyString ++ "' on JSON object `" ++ showAeson val ++ "'"
     Just v -> v
+  where
+  keyString =
+    case key of
+      Index i -> show i
+      Key x   -> x
+
 val ! Key key = error $ "Cannot lookup key `" ++ key ++ "' on non-object JSON `" ++ showAeson val ++ "'"
 val@(Aeson.Array vect) ! Index key =
   case vect V.!? key of
@@ -41,7 +47,7 @@ showAeson = unpack . Aeson.encode
 
 -- | Accessor method for JSON which fails with 'Nothing'
 (!?) :: Aeson.Value -> AesonKey -> Maybe Aeson.Value
-Aeson.Object hashmap !? Key key = HM.lookup (fromString key) hashmap
+Aeson.Object hashmap !? Key key = Aeson.lookup (fromString key) hashmap
 Aeson.Array vect !? Index key = vect V.!? key
 _ !? _ = Nothing
 


### PR DESCRIPTION
Previously the instance was incorrect because it'd cause an infinite loop.

This version rearranges the fields of the records to ensure that the
hash field is first, which makes it possible to derive `Eq` and `Ord`.

We also do a bunch of refactoring to use record notation instead of
constructor pattern matching, to make it easier to do similar refactoring
in the future.