### PR TITLE
Allow building with `transformers-0.6.*` (GHC 9.6)

### DIFF
--- a/language-rust.cabal
+++ b/language-rust.cabal
@@ -86,7 +86,7 @@ library
 
   build-depends:       base                 >=4.9  && <5.0
                      , prettyprinter        >=1.0  && <2.0
-                     , transformers         >=0.4  && <0.6
+                     , transformers         >=0.4  && <0.7
                      , array                >=0.5  && <0.6
                      , deepseq              >=1.1  && <1.5
 


### PR DESCRIPTION
Fixes #44.